### PR TITLE
Translation: FAQ > Virtual DOM and Internals [Ready for review]

### DIFF
--- a/content/docs/faq-internals.md
+++ b/content/docs/faq-internals.md
@@ -1,6 +1,6 @@
 ---
 id: faq-internals
-title: DOM virtual e Internos
+title: DOM virtual y detalles de implementación
 permalink: docs/faq-internals.html
 layout: docs
 category: FAQ

--- a/content/docs/faq-internals.md
+++ b/content/docs/faq-internals.md
@@ -1,23 +1,23 @@
 ---
 id: faq-internals
-title: Virtual DOM and Internals
+title: DOM virtual e Internos
 permalink: docs/faq-internals.html
 layout: docs
 category: FAQ
 ---
 
-### What is the Virtual DOM? {#what-is-the-virtual-dom}
+### ¿Qué es el DOM virtual? {#what-is-the-virtual-dom}
 
-The virtual DOM (VDOM) is a programming concept where an ideal, or "virtual", representation of a UI is kept in memory and synced with the "real" DOM by a library such as ReactDOM. This process is called [reconciliation](/docs/reconciliation.html).
+El DOM virtual (VDOM) es un concepto de programación donde una representación ideal o "virtual" de la UI se mantiene en memoria y en sincronía con el DOM "real", mediante una biblioteca como ReactDOM. Este proceso se conoce como [reconciliación](/docs/reconciliation.html).
 
-This approach enables the declarative API of React: You tell React what state you want the UI to be in, and it makes sure the DOM matches that state. This abstracts out the attribute manipulation, event handling, and manual DOM updating that you would otherwise have to use to build your app.
+Este enfoque hace posible la API declarativa de React: le dices a React en qué estado quieres que esté la UI, y se hará cargo de llevar el DOM a ese estado. Esto abstrae la manipulación de atributos, manejo de eventos y actualización manual del DOM que de otra manera tendrías que usar para construir tu aplicación.
 
-Since "virtual DOM" is more of a pattern than a specific technology, people sometimes say it to mean different things. In React world, the term "virtual DOM" is usually associated with [React elements](/docs/rendering-elements.html) since they are the objects representing the user interface. React, however, also uses internal objects called "fibers" to hold additional information about the component tree. They may also be considered a part of "virtual DOM" implementation in React.
+Ya que "DOM virtual" es más un patrón que una tecnología específica, las personas a veces le dan significados diferentes. En el mundo de React, el término "DOM virtual" es normalmente asociado con [elementos de React](/docs/rendering-elements.html) ya que son objetos representando la interfaz de usuario. Sin embargo, React también usa objetos internos llamados "fibers" para mantener información adicional acerca del arbol de componentes. Éstos pueden ser también considerados como parte de la implementación de "DOM virtual" de React.
 
-### Is the Shadow DOM the same as the Virtual DOM? {#is-the-shadow-dom-the-same-as-the-virtual-dom}
+### ¿Es el Shadow DOM lo mismo que el DOM virtual? {#is-the-shadow-dom-the-same-as-the-virtual-dom}
 
-No, they are different. The Shadow DOM is a browser technology designed primarily for scoping variables and CSS in web components. The virtual DOM is a concept implemented by libraries in JavaScript on top of browser APIs.
+No, son diferentes. El Shadow DOM es una tecnología de los navegadores diseñada principalmente para limitar el alcance de variables y CSS en componentes web. El DOM virtual es un concepto que implementan bibliotecas en JavaScript por encima de las APIs de los navegadores.
 
-### What is "React Fiber"? {#what-is-react-fiber}
+### ¿Qué es "React Fiber"? {#what-is-react-fiber}
 
-Fiber is the new reconciliation engine in React 16. Its main goal is to enable incremental rendering of the virtual DOM. [Read more](https://github.com/acdlite/react-fiber-architecture).
+Fiber es el nuevo motor de reconciliación en React 16. Su principal objetivo es permitir el renderizado incremental del DOM virtual. [Leer más](https://github.com/acdlite/react-fiber-architecture).

--- a/content/docs/faq-internals.md
+++ b/content/docs/faq-internals.md
@@ -8,9 +8,9 @@ category: FAQ
 
 ### ¿Qué es el DOM virtual? {#what-is-the-virtual-dom}
 
-El DOM virtual (VDOM) es un concepto de programación donde una representación ideal o "virtual" de la UI se mantiene en memoria y en sincronía con el DOM "real", mediante una biblioteca como ReactDOM. Este proceso se conoce como [reconciliación](/docs/reconciliation.html).
+El DOM virtual (VDOM) es un concepto de programación donde una representación ideal o "virtual" de la IU se mantiene en memoria y en sincronía con el DOM "real", mediante una biblioteca como ReactDOM. Este proceso se conoce como [reconciliación](/docs/reconciliation.html).
 
-Este enfoque hace posible la API declarativa de React: le dices a React en qué estado quieres que esté la UI, y se hará cargo de llevar el DOM a ese estado. Esto abstrae la manipulación de atributos, manejo de eventos y actualización manual del DOM que de otra manera tendrías que usar para construir tu aplicación.
+Este enfoque hace posible la API declarativa de React: le dices a React en qué estado quieres que esté la IU, y se hará cargo de llevar el DOM a ese estado. Esto abstrae la manipulación de atributos, manejo de eventos y actualización manual del DOM que de otra manera tendrías que usar para construir tu aplicación.
 
 Ya que "DOM virtual" es más un patrón que una tecnología específica, las personas a veces le dan significados diferentes. En el mundo de React, el término "DOM virtual" es normalmente asociado con [elementos de React](/docs/rendering-elements.html) ya que son objetos representando la interfaz de usuario. Sin embargo, React también usa objetos internos llamados "fibers" para mantener información adicional acerca del árbol de componentes. Éstos pueden ser también considerados como parte de la implementación de "DOM virtual" de React.
 

--- a/content/docs/faq-internals.md
+++ b/content/docs/faq-internals.md
@@ -12,7 +12,7 @@ El DOM virtual (VDOM) es un concepto de programación donde una representación 
 
 Este enfoque hace posible la API declarativa de React: le dices a React en qué estado quieres que esté la UI, y se hará cargo de llevar el DOM a ese estado. Esto abstrae la manipulación de atributos, manejo de eventos y actualización manual del DOM que de otra manera tendrías que usar para construir tu aplicación.
 
-Ya que "DOM virtual" es más un patrón que una tecnología específica, las personas a veces le dan significados diferentes. En el mundo de React, el término "DOM virtual" es normalmente asociado con [elementos de React](/docs/rendering-elements.html) ya que son objetos representando la interfaz de usuario. Sin embargo, React también usa objetos internos llamados "fibers" para mantener información adicional acerca del arbol de componentes. Éstos pueden ser también considerados como parte de la implementación de "DOM virtual" de React.
+Ya que "DOM virtual" es más un patrón que una tecnología específica, las personas a veces le dan significados diferentes. En el mundo de React, el término "DOM virtual" es normalmente asociado con [elementos de React](/docs/rendering-elements.html) ya que son objetos representando la interfaz de usuario. Sin embargo, React también usa objetos internos llamados "fibers" para mantener información adicional acerca del árbol de componentes. Éstos pueden ser también considerados como parte de la implementación de "DOM virtual" de React.
 
 ### ¿Es el Shadow DOM lo mismo que el DOM virtual? {#is-the-shadow-dom-the-same-as-the-virtual-dom}
 


### PR DESCRIPTION
The translation is ready for any feedback that you can provide @dmoralesm, @carburo, and @alejandronanez. 

I'm not really happy with these points:
- The title. I couldn't find a better translation for `Internals`, I thought on something like `DOM virtual y la implementación de React`, do you think that it is more accurate that the current one?
- I choose to kept `Shadow DOM` untranslated, because `DOM sombra` doesn't sound really good to me. On the other hand `Virtual DOM` is translated to `DOM Virtual`, which is a bit incosistent. Do you want to keep both of them untranslated or have any other idea for this? 

Relates to issue #4. 