### PR TITLE
Change from reactjs.org to es.reactjs.org

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@
 module.exports = {
   siteMetadata: {
     title: 'React: A JavaScript library for building user interfaces',
-    siteUrl: 'https://reactjs.org',
+    siteUrl: 'https://es.reactjs.org',
     rssFeedTitle: 'React',
     rssFeedDescription: 'A JavaScript library for building user interfaces',
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "bugs": {
-    "url": "https://github.com/reactjs/reactjs.org"
+    "url": "https://github.com/reactjs/es.reactjs.org"
   },
   "dependencies": {
     "babel-eslint": "^8.0.1",
@@ -60,7 +60,7 @@
     "node": ">8.4.0",
     "yarn": "^1.3.2"
   },
-  "homepage": "https://reactjs.org/",
+  "homepage": "https://es.reactjs.org/",
   "keywords": [
     "gatsby"
   ],
@@ -68,7 +68,7 @@
   "main": "n/a",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactjs/reactjs.org.git"
+    "url": "git+https://github.com/reactjs/es.reactjs.org.git"
   },
   "scripts": {
     "build": "gatsby build",

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -112,10 +112,10 @@ const MarkdownPage = ({
                   <div css={{marginTop: 80}}>
                     <a
                       css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/reactjs/reactjs.org/tree/master/${
+                      href={`https://github.com/reactjs/es.reactjs.org/tree/master/${
                         markdownRemark.fields.path
                       }`}>
-                      Edit this page
+                      Edita esta página
                     </a>
                   </div>
                 )}

--- a/src/html.js
+++ b/src/html.js
@@ -7,7 +7,7 @@ const JS_NPM_URLS = [
 export default class HTML extends React.Component {
   render() {
     return (
-      <html lang="en" {...this.props.htmlAttributes}>
+      <html lang="es" {...this.props.htmlAttributes}>
         <head>
           {JS_NPM_URLS.map(url => (
             <link key={url} rel="preload" href={url} as="script" />

--- a/src/site-constants.js
+++ b/src/site-constants.js
@@ -7,7 +7,7 @@
 
 // NOTE: We can't just use `location.toString()` because when we are rendering
 // the SSR part in node.js we won't have a proper location.
-const urlRoot = 'https://reactjs.org';
+const urlRoot = 'https://es.reactjs.org';
 const version = '16.8.1';
 const babelURL = 'https://unpkg.com/babel-standalone@6.26.0/babel.min.js';
 


### PR DESCRIPTION
Ready for review.

I change reactjs.org links to es.reactjs.org

👇🏼👇🏼👇🏼👇🏼👇🏼👇🏼
https://github.com/reactjs/es.reactjs.org/issues/158#issue-411040962

* [x] package.json
* [x] site-constants.js
* [x]  gatsby-config.js
* [x]  MarkdownPage (the link href in "Edit this page") also I change Edit this page to Edita esta Página

And change lang es
* [x]  Change `html.js` to have the attribute `lang="es"`

@dmoralesm @carburo @alejandronanez 
