### PR TITLE
Fix imperative of verb crear on home page

### DIFF
--- a/content/home/marketing/component-based.md
+++ b/content/home/marketing/component-based.md
@@ -3,7 +3,7 @@ title: Basado en componentes
 order: 1
 ---
 
-Cree componentes encapsulados que manejen su propio estado,
+Crea componentes encapsulados que manejen su propio estado,
 y conviértelos en interfaces de usuario complejas.
 
 Ya que la lógica de los componentes está escrita en JavaScript y no en plantillas,


### PR DESCRIPTION
In the marketing section of the home page, there's a block of text titled "Basado en componentes". This PR fixes the imperative form of the verb create on that paragraph.