### PR TITLE
Fix weird headings in home page code examples

### DIFF
--- a/src/components/CodeExample/CodeExample.js
+++ b/src/components/CodeExample/CodeExample.js
@@ -41,7 +41,7 @@ class CodeExample extends Component {
 
               '& h3': {
                 color: colors.dark,
-                maxWidth: '11em',
+                // maxWidth: '11em',
                 paddingTop: 0,
               },
 


### PR DESCRIPTION
I don't really know why the English version has that max-width either. I might raise an issue there 🤷‍♀️

Before:
<img width="764" alt="screen shot 2019-02-16 at 6 17 43 pm" src="https://user-images.githubusercontent.com/1278991/52907757-cfe6e700-321c-11e9-81e6-f6ba7ec55922.png">
<img width="763" alt="screen shot 2019-02-16 at 6 17 49 pm" src="https://user-images.githubusercontent.com/1278991/52907756-ccebf680-321c-11e9-9cd3-9ba9379b1ec2.png">

After:
<img width="748" alt="screen shot 2019-02-16 at 6 55 46 pm" src="https://user-images.githubusercontent.com/1278991/52907760-d7a68b80-321c-11e9-88de-8c5e0a982e87.png">
<img width="774" alt="screen shot 2019-02-16 at 6 55 37 pm" src="https://user-images.githubusercontent.com/1278991/52907761-dbd2a900-321c-11e9-8cd6-371131112f8a.png">
