### PR TITLE
Fixes to search bar & untranslated link

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -104,7 +104,7 @@ class DocSearch extends Component<{}, State> {
           }}
           id="algolia-doc-search"
           type="search"
-          placeholder="Buscar en la documentación"
+          placeholder="Buscar"
           aria-label="Search docs"
         />
       </form>

--- a/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -40,7 +40,7 @@ const NavigationFooter = ({next, prev, location}) => {
           <Flex basis="50%" type="li">
             {prev && (
               <div>
-                <SecondaryLabel>Previous article</SecondaryLabel>
+                <SecondaryLabel>Artículo anterior</SecondaryLabel>
                 <div
                   css={{
                     paddingTop: 10,


### PR DESCRIPTION
Related to #158 

- As @tesseralis pointed out Search bar text is cut off on mobile, so shortening to "Buscar"
- Add translation for "Next Article" link