### PR TITLE
add docsearch

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -22,8 +22,8 @@ class DocSearch extends Component<{}, State> {
     // eslint-disable-next-line no-undef
     if (window.docsearch) {
       window.docsearch({
-        apiKey: '36221914cce388c46d0420343e0bb32e',
-        indexName: 'react',
+        apiKey: 'c768ab92aabcfa2883092851022a378b',
+        indexName: 'reactjs_es',
         inputSelector: '#algolia-doc-search',
       });
     } else {


### PR DESCRIPTION
There's currently a bug where links to anchors don't actually work (try searching once the netlify build deploys). It goes to `#__gatsby`, which is the top level id. It might have something to do with the differences in config between [react](https://github.com/algolia/docsearch-configs/blob/master/configs/react.json) and [reactjs_es](https://github.com/algolia/docsearch-configs/blob/master/configs/reactjs_es.json).

@s-pace maybe you can help us get this working?