### PR TITLE
Implementation notes translation

### DIFF
--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -19,7 +19,7 @@ El reconciliador de pila se usó en React 15 y también en versiones anteriores.
 
 ### Video: Construyendo React desde 0 {#video-building-react-from-scratch}
 
-[Paul O'Shannessy](https://twitter.com/zpao) dió una charla sobre [construir React desde 0](https://www.youtube.com/watch?v=_MAD4Oly9yg) que inspiró este documento.
+[Paul O'Shannessy](https://twitter.com/zpao) dio una charla sobre [construir React desde 0](https://www.youtube.com/watch?v=_MAD4Oly9yg) que inspiró este documento.
 
 Tanto este documento como su charla son simplificaciones del código base real por lo que obtendrás un mejor entendimiento familiarizándote con ambos.
 

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -8,6 +8,7 @@ next: design-principles.html
 redirect_from:
   - "contributing/implementation-notes.html"
 ---
+
 Esta sección es una colección de notas de implementación para el [reconciliador de pila](/docs/codebase-overview.html#stack-reconciler).
 
 Es muy técnica y asume un gran entendimiento de la API pública de React como también sobre la división de React en núcleo, renderizadores y el reconciliador. Si no estás muy familiarizado con el código base de React, primero lee la [visión general del código base](/docs/codebase-overview.html).
@@ -124,6 +125,7 @@ Si la propiedad `type` de un elemento es una *string*, sabemos que estamos traba
 console.log(<div />);
 // { type: 'div', props: {} }
 ```
+
 No hay código definido por el usuario asociado con elementos principales.
 
 Cuando el reconciliador encuentra un elemento principal, deja que el renderizador se encargue de montarlo. Por ejemplo, React DOM podría crear un nodo del DOM.
@@ -238,6 +240,7 @@ ReactDOM.render(<App />, rootEl);
 // Debería reutilizar el DOM existente:
 ReactDOM.render(<App />, rootEl);
 ```
+
 Sin embargo, nuestra implementación anterior solo sabe cómo montar el árbol inicial. No puede realizar actualizaciones sobre él porque no guarda toda la información necesaria, como todas las `publicInstance`s, o qué DOM `node`s corresponden a qué componentes.
 
 El código base del reconciliador de pila resuelve esto convirtiendo la función `mount()` en un método y poniéndolo en una clase. Hay inconvenientes con este enfoque, y estamos yendo en la dirección opuesta con la [reescritura en curso del reconciliador](/docs/codebase-overview.html#fiber-reconciler). A pesar de eso así es como funciona ahora.
@@ -453,6 +456,7 @@ class CompositeComponent {
   }
 }
 ```
+
 Para `DomComponent`, el desmontaje le avisa a cada hijo que se debe desmontar:
 
 ```js

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -45,7 +45,7 @@ El reconciliador comprobará si `App` es una clase o una función.
 
 Si `App` es una función, el reconciliador llamará `App(props)` para renderizar el elemento.
 
-Si `App` es una clase, el reconciliador instanciará una `App` con `new App(props)`, llamará al método del ciclo de vida `componentWillMount()`, y por último llamará al método `render()` para obtener el método renderizado.
+Si `App` es una clase, el reconciliador instanciará una `App` con `new App(props)`, llamará al método del ciclo de vida `componentWillMount()`, y por último llamará al método `render()` para obtener el elemento renderizado.
 
 De cualquier manera, el reconciliador averiguará a que elemento se renderizó `App`.
 
@@ -116,9 +116,9 @@ Hagamos un repaso de algunas ideas clave con el ejemplo anterior:
 
 Este proceso sería inservible si no renderizáramos algo en la pantalla como resultado.
 
-Sumados a los componentes definidos por el usuario ("compuestos"), los elementos de React también pueden representar componentes específicos a la plataforma ("principales"). Por ejemplo, `Button` puede devolver un `<div />` desde su método render.
+Sumados a los componentes definidos por el usuario o ("compuestos"), los elementos de React también pueden representar componentes específicos a la plataforma o ("principales"). Por ejemplo, `Button` puede devolver un `<div />` desde su método render.
 
-Si la propiedad `type` de un elemento es una *string*, estamos trabajando con un elemento principal:
+Si la propiedad `type` de un elemento es una *string*, sabemos que estamos trabajando con un elemento principal:
 
 ```js
 console.log(<div />);
@@ -229,7 +229,7 @@ rootEl.appendChild(node);
 
 Esto funciona pero todavía está lejos de ser la implementación real del reconciliador. El ingrediente faltante clave es el soporte para actualizaciones.
 
-### Introducción a Instancias Internas {#introducing-internal-instances}
+### Introduciendo Instancias Internas {#introducing-internal-instances}
 
 La característica clave de React es que puedes re-renderizar todo, y no recreará el DOM or reiniciará el estado:
 
@@ -834,7 +834,7 @@ function mountTree(element, containerNode) {
 }
 ```
 
-Si ahora llamamos a `mountTree()` dos veces con el mismo tipo no es destructivo:
+Ahora llamar a `mountTree()` dos veces con el mismo tipo no es destructivo:
 
 ```js
 var rootEl = document.getElementById('root');

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -74,7 +74,7 @@ function mount(element) {
   // o creando una instancia y llamando a render().
   var renderedElement;
   if (isClass(type)) {
-    // Componente de clase
+    // Clase componente
     var publicInstance = new type(props);
     // Establecer las props
     publicInstance.props = props;

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -22,7 +22,7 @@ El reconciliador de pila se usó en React 15 y también en versiones anteriores.
 
 Tanto este documento como su charla son simplificaciones del código base real por lo que obtendrás un mejor entendimiento familiarizándote con ambos.
 
-### Visión general {#overview}
+### Visión General {#overview}
 
 El reconciliador por sí mismo no tiene una API pública. Los [renderizadores](/docs/codebase-overview.html#stack-renderers) como React DOM y React Native lo usan para actualizar de manera eficiente la interfaz de usuario acorde a los componentes de React diseñados por el usuario. 
 
@@ -112,7 +112,7 @@ Hagamos un repaso de algunas ideas clave con el ejemplo anterior:
 * Los componentes definidos por el usuario (Por ej. `App`) pueden ser clases o funciones pero todos "se renderizan" como elementos.
 * El "montaje" es un proceso recursivo que crea un DOM o un árbol nativo dado el elemento de React de mayor nivel (Por ej. `<App />`).
 
-### Montando elementos principales {#mounting-host-elements}
+### Montando Elementos Principales {#mounting-host-elements}
 
 Este proceso sería inservible si no renderizáramos algo en la pantalla como resultado.
 
@@ -235,7 +235,7 @@ La característica clave de React es que puedes re-renderizar todo, y no recrear
 
 ```js
 ReactDOM.render(<App />, rootEl);
-// Debería reusar el DOM existente:
+// Debería reutilizar el DOM existente:
 ReactDOM.render(<App />, rootEl);
 ```
 Sin embargo, nuestra implementación anterior solo sabe cómo montar el árbol inicial. No puede realizar actualizaciones sobre él porque no guarda toda la información necesaria, como todas las `publicInstance`s, o qué DOM `node`s corresponden a qué componentes.
@@ -514,13 +514,13 @@ Ahora, ejecutando `unmountTree()`, o ejecutando `mountTree()` repetidamente, rem
 
 ### Actualizando {#updating}
 
-En la sección anterior, implementamos el desmontaje. Sin embargo React no sería muy útil si cada cambio en una prop desmontara y montara el árbol entero. El objetivo del reconciliador es el de reusar instancias existentes donde sea posible para preservar el DOM y el estado:
+En la sección anterior, implementamos el desmontaje. Sin embargo React no sería muy útil si cada cambio en una prop desmontara y montara el árbol entero. El objetivo del reconciliador es el de reutilizar instancias existentes donde sea posible para preservar el DOM y el estado:
 
 ```js
 var rootEl = document.getElementById('root');
 
 mountTree(<App />, rootEl);
-// Debería reusar el DOM existente:
+// Debería reutilizar el DOM existente:
 mountTree(<App />, rootEl);
 ```
 
@@ -548,7 +548,7 @@ Su trabajo es hacer lo necesario para mantener el componente (y a cualquiera de 
 
 Esta es la parte frecuentemente descripta como "diferenciación del virtual DOM" aunque lo que realmente sucede es que recorremos el árbol interno recursivamente y dejamos que cada instancia interna reciba una actualización.
 
-### Actualizando componentes compuestos {#updating-composite-components}
+### Actualizando Componentes Compuestos {#updating-composite-components}
 
 Cuando un componente compuesto recibe un nuevo elemento, ejecutamos el método de ciclo de vida `componentWillUpdate()`.
 
@@ -598,7 +598,7 @@ Por ejemplo, si devuelve `<Button color="red" />` la primera vez, y `<Button col
     // ...
 
     // Si el tipo del elemento renderizado no cambió,
-    // reusar la instancia existente del componente y salir.
+    // reutilizar la instancia existente del componente y salir.
     if (prevRenderedElement.type === nextRenderedElement.type) {
       prevRenderedComponent.receive(nextRenderedElement);
       return;
@@ -662,7 +662,7 @@ class DOMComponent {
 }
 ```
 
-### Actualizando componentes principales {#updating-host-components}
+### Actualizando Componentes Principales {#updating-host-components}
 
 Las implementaciones de componentes principales, como `DOMComponent`, se actualizan de manera diferente. Cuando reciben un elemento, necesitan actualizar la vista subyacente específica a la plataforma.
 
@@ -807,25 +807,25 @@ Como último paso, ejecutamos las operaciones del DOM. Nuevamente, el código de
 
 Y eso es todo para actualizar los componentes principales.
 
-### Top-Level Updates {#top-level-updates}
+### Actualizaciones de Mayor Nivel {#top-level-updates}
 
-Now that both `CompositeComponent` and `DOMComponent` implement the `receive(nextElement)` method, we can change the top-level `mountTree()` function to use it when the element `type` is the same as it was the last time:
+Ahora que tanto `CompositeComponent` como `DOMComponent` implementan el método `receive(nextElement)`, podemos cambiar la función de mayor nivel `mountTree()` para usarla cuando el `type` del elemento sea el mismo que la última vez:
 
 ```js
 function mountTree(element, containerNode) {
-  // Check for an existing tree
+  // Verificar por un árbol existente
   if (containerNode.firstChild) {
     var prevNode = containerNode.firstChild;
     var prevRootComponent = prevNode._internalInstance;
     var prevElement = prevRootComponent.currentElement;
 
-    // If we can, reuse the existing root component
+    // Si podemos, reutilizar el componente raíz existente
     if (prevElement.type === element.type) {
       prevRootComponent.receive(element);
       return;
     }
 
-    // Otherwise, unmount the existing tree
+    // En el otro caso, desmontar el árbol existente
     unmountTree(containerNode);
   }
 
@@ -834,61 +834,61 @@ function mountTree(element, containerNode) {
 }
 ```
 
-Now calling `mountTree()` two times with the same type isn't destructive:
+Si ahora llamamos a `mountTree()` dos veces con el mismo tipo no es destructivo:
 
 ```js
 var rootEl = document.getElementById('root');
 
 mountTree(<App />, rootEl);
-// Reuses the existing DOM:
+// Reutiliza el DOM existente:
 mountTree(<App />, rootEl);
 ```
 
-These are the basics of how React works internally.
+Esto es lo básico sobre cómo funciona React internamente.
 
-### What We Left Out {#what-we-left-out}
+### Lo Que Dejamos Fuera {#what-we-left-out}
 
-This document is simplified compared to the real codebase. There are a few important aspects we didn't address:
+Este documento está simplificado en comparación al código base real. Hay algunos aspectos importantes que no abordamos:
 
-* Components can render `null`, and the reconciler can handle "empty slots" in arrays and rendered output.
+* Los componentes pueden renderizar `null`, y el reconciliador puede aceptar "espacios vacíos" en *arrays* y resultados renderizados.
 
-* The reconciler also reads `key` from the elements, and uses it to establish which internal instance corresponds to which element in an array. A bulk of complexity in the actual React implementation is related to that.
+* El reconciliador también lee la `key` de los elementos, y la usa para establecer a qué instancia interna corresponde cada elemento en un *array*. Una gran parte de la complejidad en la implementación actual de React tiene que ver con eso.
 
-* In addition to composite and host internal instance classes, there are also classes for "text" and "empty" components. They represent text nodes and the "empty slots" you get by rendering `null`.
+* Además de clases de instancias internas principales y compuestas, también existen clases para componentes de "texto" y "vacíos". Representan nodos de texto y los "espacios vacíos" que se obtienen al renderizar `null`.
 
-* Renderers use [injection](/docs/codebase-overview.html#dynamic-injection) to pass the host internal class to the reconciler. For example, React DOM tells the reconciler to use `ReactDOMComponent` as the host internal instance implementation.
+* Los renderizadores usan [inyección](/docs/codebase-overview.html#dynamic-injection) para pasar la clase interna principal al reconciliador. Por ejemplo, React DOM le dice al reconciliador que use `ReactDOMComponent` como la implementación de una instancia interna principal.
 
-* The logic for updating the list of children is extracted into a mixin called `ReactMultiChild` which is used by the host internal instance class implementations both in React DOM and React Native.
+* La lógica para actualizar la lista de hijos es extraída a una mezcla llamada `ReactMultiChild` que es utilizada por las implementaciones de clases de instancias internas principales tanto para React DOM como para React Native.
 
-* The reconciler also implements support for `setState()` in composite components. Multiple updates inside event handlers get batched into a single update.
+* El reconciliador además implementa soporte para `setState()` en componentes compuestos. Múltiples actualizaciones dentro de escuchadores de eventos son procesadas por lote en una sola actualización.
 
-* The reconciler also takes care of attaching and detaching refs to composite components and host nodes.
+* El reconciliador también se encarga de adjuntar y desconectar las referencias a componentes compuestos y nodos principales.
 
-* Lifecycle methods that are called after the DOM is ready, such as `componentDidMount()` and `componentDidUpdate()`, get collected into "callback queues" and are executed in a single batch.
++ Los métodos de ciclo de vida que son llamados después de que el DOM está listo, como `componentDidMount()` and `componentDidUpdate()`, son recogidos en "colas de callbacks" y son ejecutados en un solo lote.
 
-* React puts information about the current update into an internal object called "transaction". Transactions are useful for keeping track of the queue of pending lifecycle methods, the current DOM nesting for the warnings, and anything else that is "global" to a specific update. Transactions also ensure React "cleans everything up" after updates. For example, the transaction class provided by React DOM restores the input selection after any update.
+* React pone información sobre la actualización en curso dentro de un objeto interno llamado "transacción". Las transacciones son útiles para hacer un seguimiento de la cola de métodos de ciclo de vida pendientes, la anidación actual del DOM para las alertas, y todo lo demás que sea "global" a una actualización específica. Las transacciones también aseguran que React "limpie todo" luego de las actualizaciones. Por ejemplo, la clase transacción provista por React DOM restaura la selección del *input* después de cada actualización.
 
-### Jumping into the Code {#jumping-into-the-code}
+### Metiéndose con el Código {#jumping-into-the-code}
 
-* [`ReactMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/client/ReactMount.js) is where the code like `mountTree()` and `unmountTree()` from this tutorial lives. It takes care of mounting and unmounting top-level components. [`ReactNativeMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeMount.js) is its React Native analog.
-* [`ReactDOMComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/shared/ReactDOMComponent.js) is the equivalent of `DOMComponent` in this tutorial. It implements the host component class for React DOM renderer. [`ReactNativeBaseComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeBaseComponent.js) is its React Native analog.
-* [`ReactCompositeComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js) is the equivalent of `CompositeComponent` in this tutorial. It handles calling user-defined components and maintaining their state.
-* [`instantiateReactComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/instantiateReactComponent.js) contains the switch that picks the right internal instance class to construct for an element. It is equivalent to `instantiateComponent()` in this tutorial.
+* [`ReactMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/client/ReactMount.js) es donde está el código de `mountTree()` y `unmountTree()` de este tutorial. Se encarga de montar y desmontar componentes de mayor nivel. [`ReactNativeMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeMount.js) es su análogo en React Native.
+* [`ReactDOMComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/shared/ReactDOMComponent.js) es el equivalente a `DOMComponent` en este tutorial. Implementa la clase de los componentes principales para el renderizador React DOM. [`ReactNativeBaseComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeBaseComponent.js) es su análogo en React Native.
+* [`ReactCompositeComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js) es el equivalente a `CompositeComponent` es este tutorial. Maneja las llamadas a componentes definidos por el usuario y el mantenimiento de su estado.
+* [`instantiateReactComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/instantiateReactComponent.js) contiene el interruptor que elige la clase correcta de una instancia interna a construir para un elemento. Es equivalente a `instantiateComponent()` en este tutorial.
 
-* [`ReactReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactReconciler.js) is a wrapper with `mountComponent()`, `receiveComponent()`, and `unmountComponent()` methods. It calls the underlying implementations on the internal instances, but also includes some code around them that is shared by all internal instance implementations.
+* [`ReactReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactReconciler.js) es un *wrapper* que contiene los métodos `mountComponent()`, `receiveComponent()`, y `unmountComponent()`. Llama a las implementaciones subyacentes en las instancias internas, pero también incluye código sobre ellas que es compartido por todas las implementaciones de instancias internas.
 
-* [`ReactChildReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactChildReconciler.js) implements the logic for mounting, updating, and unmounting children according to the `key` of their elements.
+* [`ReactChildReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactChildReconciler.js) implementa la lógica para montar, actualizar, y desmontar hijos de acuerdo a la `key` de sus elementos.
 
-* [`ReactMultiChild`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactMultiChild.js) implements processing the operation queue for child insertions, deletions, and moves independently of the renderer.
+* [`ReactMultiChild`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactMultiChild.js) implementa el procesamiento de la cola de operaciones para inserciones de hijos, supresiones, y movimientos independientemente del renderizador.
 
-* `mount()`, `receive()`, and `unmount()` are really called `mountComponent()`, `receiveComponent()`, and `unmountComponent()` in React codebase for legacy reasons, but they receive elements.
+* `mount()`, `receive()`, y `unmount()` son en realidad llamados `mountComponent()`, `receiveComponent()`, and `unmountComponent()` en el código base de React por razones de herencia, pero reciben elementos.
 
-* Properties on the internal instances start with an underscore, e.g. `_currentElement`. They are considered to be read-only public fields throughout the codebase.
+* Las propiedades en las instancias internas comienzan con un guión bajo, por ej. `_currentElement`. Son considerados campos públicos de sólo lectura a través del código base.
 
-### Future Directions {#future-directions}
+### Futuras Orientaciones {#future-directions}
 
-Stack reconciler has inherent limitations such as being synchronous and unable to interrupt the work or split it in chunks. There is a work in progress on the [new Fiber reconciler](/docs/codebase-overview.html#fiber-reconciler) with a [completely different architecture](https://github.com/acdlite/react-fiber-architecture). In the future, we intend to replace stack reconciler with it, but at the moment it is far from feature parity.
+El reconciliador de pila tiene limitaciones inherentes como ser sincrónico y no permitir interrumpir el trabajo o dividirlo en fragmentos. Hay trabajo en progreso en el [nuevo reconciliador Fiber](/docs/codebase-overview.html#fiber-reconciler) con una [arquitectura completamente diferente](https://github.com/acdlite/react-fiber-architecture). En el futuro, pretendemos reemplazar el reconciliador de pila con Fiber, pero por el momento está lejos de igualar sus características.
 
-### Next Steps {#next-steps}
+### Siguientes Pasos {#next-steps}
 
-Read the [next section](/docs/design-principles.html) to learn about the guiding principles we use for React development.
+Lee la [siguiente sección](/docs/design-principles.html) para aprender sobre los principios de guía que usamos para el desarrollo de React.

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -128,9 +128,9 @@ console.log(<div />);
 
 No hay código definido por el usuario asociado con elementos anfitriones.
 
-Cuando el reconciliador encuentra un elemento principal, deja que el renderizador se encargue de montarlo. Por ejemplo, React DOM podría crear un nodo del DOM.
+Cuando el reconciliador encuentra un elemento anfitrión, deja que el renderizador se encargue de montarlo. Por ejemplo, React DOM podría crear un nodo del DOM.
 
-Si el elemento principal tiene hijos, el reconciliador los monta de manera recursiva siguiendo el mismo algoritmo como en el caso anterior. No importa si los hijos son principales (como `<div><hr /></div>`), compuestos (como `<div><Button /></div>`), o ambos.
+Si el elemento anfitrión tiene hijos, el reconciliador los monta de manera recursiva siguiendo el mismo algoritmo como en el caso anterior. No importa si los hijos son anfitriones (como `<div><hr /></div>`), compuestos (como `<div><Button /></div>`), o ambos.
 
 Los nodos del DOM producidos por componentes hijos serán anexados al nodo padre del DOM, y recursivamente, la estructura completa del DOM será ensamblada.
 
@@ -138,7 +138,7 @@ Los nodos del DOM producidos por componentes hijos serán anexados al nodo padre
 >
 >El reconciliador mismo no está ligado al DOM. El resultado exacto del montaje (a veces llamado "mount image" en el código fuente) depende del renderizador, y puede ser un nodo del DOM (React DOM), una *string* (React DOM Server), o un número representando una vista nativa (React Native).
 
-Si fueramos a extender el código para aceptar elementos principales, se vería así:
+Si fueramos a extender el código para aceptar elementos anfitriones, se vería así:
 
 ```js
 function isClass(type) {
@@ -157,7 +157,7 @@ function mountComposite(element) {
 
   var renderedElement;
   if (isClass(type)) {
-    // Componente de clase
+    // Clase componente
     var publicInstance = new type(props);
     // Establecer las props
     publicInstance.props = props;
@@ -167,16 +167,16 @@ function mountComposite(element) {
     }
     renderedElement = publicInstance.render();
   } else if (typeof type === 'function') {
-    // Componente de función
+    // Función Componente
     renderedElement = type(props);
   }
-
+https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)
   // Esto es recursivo pero eventualmente alcanzaremos el final de la recursión
-  // cuando el elemento sea principal (Por ej. <div /> en vez de compuesto (Por ej. <App />):
+  // cuando el elemento sea anfitrión (Por ej. <div /> en vez de compuesto (Por ej. <App />):
   return mount(renderedElement);
 }
 
-// Esta función solo acepta elementos de tipo principal.
+// Esta función solo acepta elementos de tipo anfitrión.
 // Por ejemplo, acepta <div /> y <p /> pero no <App />.
 function mountHost(element) {
   var type = element.type;
@@ -247,7 +247,7 @@ El código base del reconciliador de pila resuelve esto convirtiendo la función
 
 En vez de funciones `mountHost` y `mountComposite` separadas, crearemos dos clases: `DOMComponent` y `CompositeComponent`.
 
-Ambas clases tienen un constructor que acepta `element`, como también un método `mount()` que devuelve el nodo montado. Vamos a reemplazar la función `mount()` de mayor nivel por una fábrica que instanciará la clase correcta:
+Ambas clases tienen un constructor que acepta `element`, como también un método `mount()` que devuelve el nodo montado. Vamos a reemplazar la función `mount()` de mayor nivel por una [fábrica](https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)) que instanciará la clase correcta:
 
 ```js
 function instantiateComponent(element) {
@@ -285,7 +285,7 @@ class CompositeComponent {
     var publicInstance;
     var renderedElement;
     if (isClass(type)) {
-      // Componente de clase
+      // Clase componente
       publicInstance = new type(props);
       // Establecer las props
       publicInstance.props = props;
@@ -295,7 +295,7 @@ class CompositeComponent {
       }
       renderedElement = publicInstance.render();
     } else if (typeof type === 'function') {
-      // Componente de función
+      // Función componente
       publicInstance = null;
       renderedElement = type(props);
     }
@@ -376,7 +376,7 @@ class DOMComponent {
 
 La principal diferencia después de refactorizar `mountHost()` es que ahora podemos mantener `this.node` y `this.renderedChildren` asociados con la instancia interna del componente del DOM. También los usaremos para aplicar actualizaciones no destructivas en el futuro.
 
-Como resultado, cada instancia interna, compuesta o principal, ahora apunta a sus instancias internas hijas. Para ayudar a visualizar esto, si el componente `<App>` de una función renderiza un componente de clase `<Button>`, y la clase `Button` renderiza un `<div>`, el árbol de la instancia interna se vería así:
+Como resultado, cada instancia interna, compuesta o anfitrión, ahora apunta a sus instancias internas hijas. Para ayudar a visualizar esto, si el componente `<App>` de una función renderiza un componente de clase `<Button>`, y la clase `Button` renderiza un `<div>`, el árbol de la instancia interna se vería así:
 
 ```js
 [object CompositeComponent] {
@@ -394,7 +394,7 @@ Como resultado, cada instancia interna, compuesta o principal, ahora apunta a su
 }
 ```
 
-En el DOM sólo verías el `<div>`. Sin embargo el árbol de la instancia interna contiene las instancias internas tanto compuesta como principal.
+En el DOM sólo verías el `<div>`. Sin embargo el árbol de la instancia interna contiene las instancias internas tanto compuestas como anfitriones.
 
 Las instancias internas compuestas necesitan almacenar:
 
@@ -402,13 +402,13 @@ Las instancias internas compuestas necesitan almacenar:
 * La instancia pública si el tipo del elemento es una clase.
 * La única instancia interna renderizada. Puede ser un `DOMComponent` o un `CompositeComponent`.
 
-Las instancias internas principales necesitan almacenar:
+Las instancias internas anfitriones necesitan almacenar:
 
 * El elemento actual.
 * El nodo del DOM.
 * Todas las instancias internas hijas. Cada una de ellas puede ser un `DOMComponent` o un `CompositeComponent`.
 
-Si se te dificulta imaginar como está estructurado un árbol de instancias internas en aplicaciones más complejas, las [React DevTools](https://github.com/facebook/react-devtools) pueden darte una aproximación, ya que resaltan las instancias principales con gris, y las instancias compuestas con lila:
+Si se te dificulta imaginar como está estructurado un árbol de instancias internas en aplicaciones más complejas, las [React DevTools](https://github.com/facebook/react-devtools) pueden darte una aproximación, ya que resaltan las instancias anfitriones con gris, y las instancias compuestas con lila:
 
  <img src="../images/docs/implementation-notes-tree.png" width="500" style="max-width: 100%" alt="React DevTools tree" />
 
@@ -577,7 +577,7 @@ class CompositeComponent {
     // Averiguar cual es el resultado del siguiente render()
     var nextRenderedElement;
     if (isClass(type)) {
-      // Componente de clase
+      // Clase componente
       // Llamar al ciclo de vida si es necesario
       if (publicInstance.componentWillUpdate) {
         publicInstance.componentWillUpdate(nextProps);
@@ -587,7 +587,7 @@ class CompositeComponent {
       // Re-renderizar
       nextRenderedElement = publicInstance.render();
     } else if (typeof type === 'function') {
-      // Componente de función
+      // Función componente
       nextRenderedElement = type(nextProps);
     }
 
@@ -666,9 +666,9 @@ class DOMComponent {
 }
 ```
 
-### Actualizando Componentes Principales {#updating-host-components}
+### Actualización de componentes anfitriones {#updating-host-components}
 
-Las implementaciones de componentes principales, como `DOMComponent`, se actualizan de manera diferente. Cuando reciben un elemento, necesitan actualizar la vista subyacente específica a la plataforma.
+Las implementaciones de componentes anfitriones, como `DOMComponent`, se actualizan de manera diferente. Cuando reciben un elemento, necesitan actualizar la vista subyacente específica a la plataforma.
 
 ```js
 class DOMComponent {
@@ -697,7 +697,7 @@ class DOMComponent {
     // ...
 ```
 
-Luego, los componentes principales necesitan actualizar sus hijos. A diferencia de los componentes compuestos, pueden contener más de un hijo.
+Luego, los componentes anfitriones necesitan actualizar sus hijos. A diferencia de los componentes compuestos, pueden contener más de un hijo.
 
 En este ejemplo simplificado, usamos un *array* de instancias internas e iteramos sobre él, ya sea actualizándolo o reemplazando las instancias internas dependiendo de si el `type` recibido coincide con el `type` anterior. El reconciliador real además tiene en cuenta la `key` del elemento y rastrea los movimientos además de las inserciones y las supresiones, pero omitiremos esta lógica por ahora.
 
@@ -809,7 +809,7 @@ Como último paso, ejecutamos las operaciones del DOM. Nuevamente, el código de
 }
 ```
 
-Y eso es todo para actualizar los componentes principales.
+Y eso es todo para actualizar los componentes anfitriones.
 
 ### Actualizaciones de Mayor Nivel {#top-level-updates}
 
@@ -858,15 +858,15 @@ Este documento está simplificado en comparación al código base real. Hay algu
 
 * El reconciliador también lee la `key` de los elementos, y la usa para establecer a qué instancia interna corresponde cada elemento en un *array*. Una gran parte de la complejidad en la implementación actual de React tiene que ver con eso.
 
-* Además de clases de instancias internas principales y compuestas, también existen clases para componentes de "texto" y "vacíos". Representan nodos de texto y los "espacios vacíos" que se obtienen al renderizar `null`.
+* Además de clases de instancias internas anfitriones y compuestas, también existen clases para componentes de "texto" y "vacíos". Representan nodos de texto y los "espacios vacíos" que se obtienen al renderizar `null`.
 
-* Los renderizadores usan [inyección](/docs/codebase-overview.html#dynamic-injection) para pasar la clase interna principal al reconciliador. Por ejemplo, React DOM le dice al reconciliador que use `ReactDOMComponent` como la implementación de una instancia interna principal.
+* Los renderizadores usan [inyección](/docs/codebase-overview.html#dynamic-injection) para pasar la clase interna anfitrión al reconciliador. Por ejemplo, React DOM le dice al reconciliador que use `ReactDOMComponent` como la implementación de una instancia interna anfitrión.
 
-* La lógica para actualizar la lista de hijos se extrae en un mixin llamado `ReactMultiChild` que es utilizado por las implementaciones de clases de instancias internas principales tanto para React DOM como para React Native.
+* La lógica para actualizar la lista de hijos se extrae en un mixin llamado `ReactMultiChild` que es utilizado por las implementaciones de clases de instancias internas anfitriones tanto para React DOM como para React Native.
 
 * La implementación del reconciliador también permite el funcionamiento de `setState()` en componentes compuestos. Múltiples actualizaciones dentro de manejadores de eventos son procesadas por lote en una sola actualización.
 
-* El reconciliador también se encarga de adjuntar y desconectar las referencias a componentes compuestos y nodos principales.
+* El reconciliador también se encarga de adjuntar y desconectar las referencias a componentes compuestos y nodos anfitriones.
 
 + Los métodos de ciclo de vida que son llamados después de que el DOM está listo, como `componentDidMount()` and `componentDidUpdate()`, son recogidos en "colas de callbacks" y son ejecutados en un solo lote.
 
@@ -875,7 +875,7 @@ Este documento está simplificado en comparación al código base real. Hay algu
 ### Metiéndose con el Código {#jumping-into-the-code}
 
 * [`ReactMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/client/ReactMount.js) es donde está el código de `mountTree()` y `unmountTree()` de este tutorial. Se encarga de montar y desmontar componentes de mayor nivel. [`ReactNativeMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeMount.js) es su análogo en React Native.
-* [`ReactDOMComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/shared/ReactDOMComponent.js) es el equivalente a `DOMComponent` en este tutorial. Implementa la clase de los componentes principales para el renderizador React DOM. [`ReactNativeBaseComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeBaseComponent.js) es su análogo en React Native.
+* [`ReactDOMComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/shared/ReactDOMComponent.js) es el equivalente a `DOMComponent` en este tutorial. Implementa la clase de los componentes anfitriones para el renderizador React DOM. [`ReactNativeBaseComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeBaseComponent.js) es su análogo en React Native.
 * [`ReactCompositeComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js) es el equivalente a `CompositeComponent` es este tutorial. Maneja las llamadas a componentes definidos por el usuario y el mantenimiento de su estado.
 * [`instantiateReactComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/instantiateReactComponent.js) contiene el interruptor que elige la clase correcta de una instancia interna a construir para un elemento. Es equivalente a `instantiateComponent()` en este tutorial.
 

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -1,6 +1,6 @@
 ---
 id: implementation-notes
-title: Implementation Notes
+title: Notas de implementación
 layout: contributing
 permalink: docs/implementation-notes.html
 prev: codebase-overview.html
@@ -8,32 +8,55 @@ next: design-principles.html
 redirect_from:
   - "contributing/implementation-notes.html"
 ---
+Esta sección es una colección de notas de implementación para el [reconciliador de pila](/docs/codebase-overview.html#stack-reconciler).
 
 This section is a collection of implementation notes for the [stack reconciler](/docs/codebase-overview.html#stack-reconciler).
 
+Es muy técnica y asume un gran entendimiento de la API pública de React como también sobre la división de React en núcleo, renderizadores y el reconciliador. Si no estás muy familiarizado con el código base de React, primero lee la [visión general del código base](/docs/codebase-overview.html).
+
 It is very technical and assumes a strong understanding of React public API as well as how it's divided into core, renderers, and the reconciler. If you're not very familiar with the React codebase, read [the codebase overview](/docs/codebase-overview.html) first.
+
+Además se asume una buena comprensión de las [diferencias entre componentes de React, sus instancias y sus elementos](/blog/2015/12/18/react-components-elements-and-instances.html).
 
 It also assumes an understanding of the [differences between React components, their instances, and elements](/blog/2015/12/18/react-components-elements-and-instances.html).
 
+El reconciliador de pila se usó en React 15 y también en versiones anteriores. Está ubicado en [src/renderers/shared/stack/reconciler](https://github.com/facebook/react/tree/15-stable/src/renderers/shared/stack/reconciler).
+
 The stack reconciler was used in React 15 and earlier. It is located at [src/renderers/shared/stack/reconciler](https://github.com/facebook/react/tree/15-stable/src/renderers/shared/stack/reconciler).
+
+### Video: Construyendo React desde 0 {#video-building-react-from-scratch}
 
 ### Video: Building React from Scratch {#video-building-react-from-scratch}
 
+[Paul O'Shannessy](https://twitter.com/zpao) dió una charla sobre [construir React desde 0](https://www.youtube.com/watch?v=_MAD4Oly9yg) que inspiró este documento.
+
 [Paul O'Shannessy](https://twitter.com/zpao) gave a talk about [building React from scratch](https://www.youtube.com/watch?v=_MAD4Oly9yg) that largely inspired this document.
+
+Tanto este documento como su charla son simplificaciones del código base real por lo que obtendrás un mejor entendimiento familiarizándote con ambos.
 
 Both this document and his talk are simplifications of the real codebase so you might get a better understanding by getting familiar with both of them.
 
+### Visión general {#overview}
+
 ### Overview {#overview}
+
+El reconciliador por sí mismo no tiene una API pública. Los [renderizadores](/docs/codebase-overview.html#stack-renderers) como React DOM y React Native lo usan para actualizar de manera eficiente la interfaz de usuario acorde a los componentes de React diseñados por el usuario. 
 
 The reconciler itself doesn't have a public API. [Renderers](/docs/codebase-overview.html#stack-renderers) like React DOM and React Native use it to efficiently update the user interface according to the React components written by the user.
 
+### Montando como un Proceso Recursivo {#mounting-as-a-recursive-process}
+
 ### Mounting as a Recursive Process {#mounting-as-a-recursive-process}
+
+Consideremos la primera vez que montas un componente:
 
 Let's consider the first time you mount a component:
 
 ```js
 ReactDOM.render(<App />, rootEl);
 ```
+
+React DOM pasará `<App />` al reconciliador. Recuerda que `<App />` es un elemento de React, es decir, una descripción de *qué* hay que renderizar. Puedes pensarlo como si fuera un objecto simple:
 
 React DOM will pass `<App />` along to the reconciler. Remember that `<App />` is a React element, that is, a description of *what* to render. You can think about it as a plain object:
 
@@ -42,9 +65,15 @@ console.log(<App />);
 // { type: App, props: {} }
 ```
 
+El reconciliador comprobará si `App` es una clase o una función.
+
 The reconciler will check if `App` is a class or a function.
 
+Si `App` es una función, el reconciliador ejecutará `App(props)` para renderizar el elemento.
+
 If `App` is a function, the reconciler will call `App(props)` to get the rendered element.
+
+Si `App` es una clase, el reconciliador instanciará una `App` con `new App(props)`, llamará al método del ciclo de vida `componentWillMount()`, y por último llamará al método `render()` para obtener el método renderizado.
 
 If `App` is a class, the reconciler will instantiate an `App` with `new App(props)`, call the `componentWillMount()` lifecycle method, and then will call the `render()` method to get the rendered element.
 

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -198,7 +198,7 @@ function mountHost(element) {
 
   // Montaje de los hijos
   children.forEach(childElement => {
-    // Los hijos pueden ser principiales (Por ej. <div />) o compuestos (Por ej. <Button />)
+    // Los hijos pueden ser anfitriones (Por ej. <div />) o compuestos (Por ej. <Button />)
     // También los montaremos de manera recursiva:
     var childNode = mount(childElement);
 

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -21,7 +21,7 @@ El reconciliador de pila se usó en React 15 y también en versiones anteriores.
 
 [Paul O'Shannessy](https://twitter.com/zpao) dio una charla sobre [construir React desde 0](https://www.youtube.com/watch?v=_MAD4Oly9yg) que inspiró este documento.
 
-Tanto este documento como su charla son simplificaciones del código base real por lo que obtendrás un mejor entendimiento familiarizándote con ambos.
+Tanto este documento como su charla son simplificaciones de la base de código real por lo que obtendrás un mejor entendimiento familiarizándote con ambos.
 
 ### Visión general {#overview}
 
@@ -111,7 +111,7 @@ Hagamos un repaso de algunas ideas clave con el ejemplo anterior:
 
 * Los elementos de React son objetos simples que representan el tipo de un componente (Por ej. `App`) y las props.
 * Los componentes definidos por el usuario (Por ej. `App`) pueden ser clases o funciones pero todos "se renderizan" como elementos.
-* El "montaje" es un proceso recursivo que crea un árbol DOM o nativo dado el elemento de React de mayor nivel (Por ej. `<App />`).
+* El "montaje" es un proceso recursivo que crea un árbol DOM o nativo dado el elemento de React de nivel superior (Por ej. `<App />`).
 
 ### Montaje de elementos anfitriones {#mounting-host-elements}
 
@@ -170,7 +170,6 @@ function mountComposite(element) {
     // Función Componente
     renderedElement = type(props);
   }
-https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)
   // Esto es recursivo pero eventualmente alcanzaremos el final de la recursión
   // cuando el elemento sea anfitrión (Por ej. <div /> en vez de compuesto (Por ej. <App />):
   return mount(renderedElement);
@@ -231,7 +230,7 @@ rootEl.appendChild(node);
 
 Esto funciona pero todavía está lejos de ser la implementación real del reconciliador. El ingrediente faltante clave es el soporte para actualizaciones.
 
-### Introduciendo Instancias Internas {#introducing-internal-instances}
+### Introducción de instancias internas {#introducing-internal-instances}
 
 La característica clave de React es que puedes re-renderizar todo, y no recreará el DOM or reiniciará el estado:
 
@@ -243,11 +242,11 @@ ReactDOM.render(<App />, rootEl);
 
 Sin embargo, nuestra implementación anterior solo sabe cómo montar el árbol inicial. No puede realizar actualizaciones sobre él porque no guarda toda la información necesaria, como todas las `publicInstance`s, o qué DOM `node`s corresponden a qué componentes.
 
-El código base del reconciliador de pila resuelve esto convirtiendo la función `mount()` en un método y poniéndolo en una clase. Hay inconvenientes con este enfoque, y estamos yendo en la dirección opuesta con la [reescritura en curso del reconciliador](/docs/codebase-overview.html#fiber-reconciler). A pesar de eso así es como funciona ahora.
+La base de código del reconciliador de pila resuelve esto convirtiendo la función `mount()` en un método y poniéndolo en una clase. Hay inconvenientes con este enfoque, y estamos yendo en la dirección opuesta con la [reescritura en curso del reconciliador](/docs/codebase-overview.html#fiber-reconciler). A pesar de eso así es como funciona ahora.
 
 En vez de funciones `mountHost` y `mountComposite` separadas, crearemos dos clases: `DOMComponent` y `CompositeComponent`.
 
-Ambas clases tienen un constructor que acepta `element`, como también un método `mount()` que devuelve el nodo montado. Vamos a reemplazar la función `mount()` de mayor nivel por una [fábrica](https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)) que instanciará la clase correcta:
+Ambas clases tienen un constructor que acepta `element`, como también un método `mount()` que devuelve el nodo montado. Vamos a reemplazar la función `mount()` de nivel superior por una [fábrica](https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)) que instanciará la clase correcta:
 
 ```js
 function instantiateComponent(element) {
@@ -416,10 +415,10 @@ Para completar esta refactorización, introduciremos una función que monta el �
 
 ```js
 function mountTree(element, containerNode) {
-  // Crear la instancia interna de mayor nivel
+  // Crear la instancia interna de nivel superior
   var rootComponent = instantiateComponent(element);
 
-  // Montar el componente de mayor nivel al contenedor
+  // Montar el componente de nivel superior al contenedor
   var node = rootComponent.mount();
   containerNode.appendChild(node);
 
@@ -472,9 +471,9 @@ class DOMComponent {
 }
 ```
 
-En la práctica, desmontar componentes del DOM también remueve los escuchadores de eventos y limpia algunas cachés, pero nos saltearemos esos detalles.
+En la práctica, desmontar componentes del DOM también remueve los manejadores de eventos y limpia algunas cachés, pero nos saltearemos esos detalles.
 
-Ahora podemos agregar una nueva función de mayor nivel llamada `unmountTree(containerNode)` que es similar a `ReactDOM.unmountComponentAtNode()`:
+Ahora podemos agregar una nueva función de nivel superior llamada `unmountTree(containerNode)` que es similar a `ReactDOM.unmountComponentAtNode()`:
 
 ```js
 function unmountTree(containerNode) {
@@ -498,10 +497,10 @@ function mountTree(element, containerNode) {
     unmountTree(containerNode);
   }
 
-  // Creaer la instancia interna de mayor nivel
+  // Creaer la instancia interna de nivel superior
   var rootComponent = instantiateComponent(element);
 
-  // Montar el componente de mayor nivel al contenedor
+  // Montar el componente de nivel superior al contenedor
   var node = rootComponent.mount();
   containerNode.appendChild(node);
 
@@ -516,7 +515,7 @@ function mountTree(element, containerNode) {
 
 Ahora, ejecutando `unmountTree()`, o ejecutando `mountTree()` repetidamente, remueve el árbol viejo y ejecuta el método de ciclo de vida `componentWillUnmount()` en los componentes.
 
-### Actualizando {#updating}
+### Actualización {#updating}
 
 En la sección anterior, implementamos el desmontaje. Sin embargo React no sería muy útil si cada cambio en una prop desmontara y montara el árbol entero. El objetivo del reconciliador es el de reutilizar instancias existentes donde sea posible para preservar el DOM y el estado:
 
@@ -552,7 +551,7 @@ Su trabajo es hacer lo necesario para mantener el componente (y a cualquiera de 
 
 Esta es la parte frecuentemente descripta como "diferenciación del virtual DOM" aunque lo que realmente sucede es que recorremos el árbol interno recursivamente y dejamos que cada instancia interna reciba una actualización.
 
-### Actualizando Componentes Compuestos {#updating-composite-components}
+### Actualización de componentes compuestos {#updating-composite-components}
 
 Cuando un componente compuesto recibe un nuevo elemento, ejecutamos el método de ciclo de vida `componentWillUpdate()`.
 
@@ -811,9 +810,9 @@ Como último paso, ejecutamos las operaciones del DOM. Nuevamente, el código de
 
 Y eso es todo para actualizar los componentes anfitriones.
 
-### Actualizaciones de Mayor Nivel {#top-level-updates}
+### Actualizaciones de nivel superior {#top-level-updates}
 
-Ahora que tanto `CompositeComponent` como `DOMComponent` implementan el método `receive(nextElement)`, podemos cambiar la función de mayor nivel `mountTree()` para usarla cuando el `type` del elemento sea el mismo que la última vez:
+Ahora que tanto `CompositeComponent` como `DOMComponent` implementan el método `receive(nextElement)`, podemos cambiar la función de nivel superior `mountTree()` para usarla cuando el `type` del elemento sea el mismo que la última vez:
 
 ```js
 function mountTree(element, containerNode) {
@@ -850,9 +849,9 @@ mountTree(<App />, rootEl);
 
 Esto es lo básico sobre cómo funciona React internamente.
 
-### Lo Que Dejamos Fuera {#what-we-left-out}
+### Lo que dejamos fuera {#what-we-left-out}
 
-Este documento está simplificado en comparación al código base real. Hay algunos aspectos importantes que no abordamos:
+Este documento está simplificado en comparación a la base de código real. Hay algunos aspectos importantes que no abordamos:
 
 * Los componentes pueden renderizar `null`, y el reconciliador puede aceptar "espacios vacíos" en *arrays* y resultados renderizados.
 
@@ -872,9 +871,9 @@ Este documento está simplificado en comparación al código base real. Hay algu
 
 * React pone información sobre la actualización en curso dentro de un objeto interno llamado "transacción". Las transacciones son útiles para hacer un seguimiento de la cola de métodos de ciclo de vida pendientes, la anidación actual del DOM para las alertas, y todo lo demás que sea "global" a una actualización específica. Las transacciones también aseguran que React "limpie todo" luego de las actualizaciones. Por ejemplo, la clase transacción provista por React DOM restaura la selección del *input* después de cada actualización.
 
-### Metiéndose con el Código {#jumping-into-the-code}
+### Metiéndose al código {#jumping-into-the-code}
 
-* [`ReactMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/client/ReactMount.js) es donde está el código de `mountTree()` y `unmountTree()` de este tutorial. Se encarga de montar y desmontar componentes de mayor nivel. [`ReactNativeMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeMount.js) es su análogo en React Native.
+* [`ReactMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/client/ReactMount.js) es donde está el código de `mountTree()` y `unmountTree()` de este tutorial. Se encarga de montar y desmontar componentes de nivel superior. [`ReactNativeMount`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeMount.js) es su análogo en React Native.
 * [`ReactDOMComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/dom/shared/ReactDOMComponent.js) es el equivalente a `DOMComponent` en este tutorial. Implementa la clase de los componentes anfitriones para el renderizador React DOM. [`ReactNativeBaseComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/native/ReactNativeBaseComponent.js) es su análogo en React Native.
 * [`ReactCompositeComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js) es el equivalente a `CompositeComponent` es este tutorial. Maneja las llamadas a componentes definidos por el usuario y el mantenimiento de su estado.
 * [`instantiateReactComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/instantiateReactComponent.js) contiene el interruptor que elige la clase correcta de una instancia interna a construir para un elemento. Es equivalente a `instantiateComponent()` en este tutorial.
@@ -885,14 +884,14 @@ Este documento está simplificado en comparación al código base real. Hay algu
 
 * [`ReactMultiChild`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactMultiChild.js) implementa el procesamiento de la cola de operaciones para inserciones de hijos, supresiones, y movimientos independientemente del renderizador.
 
-* `mount()`, `receive()`, y `unmount()` son en realidad llamados `mountComponent()`, `receiveComponent()`, and `unmountComponent()` en el código base de React por razones de herencia, pero reciben elementos.
+* `mount()`, `receive()`, y `unmount()` son en realidad llamados `mountComponent()`, `receiveComponent()`, y `unmountComponent()` en la base de código de React por razones de herencia, pero reciben elementos.
 
 * Las propiedades en las instancias internas comienzan con un guión bajo, por ej. `_currentElement`. Son considerados campos públicos de solo lectura a través de la base de código.
 
-### Futuras Orientaciones {#future-directions}
+### Futuras direcciones {#future-directions}
 
 El reconciliador de pila tiene limitaciones inherentes como ser sincrónico y no permitir interrumpir el trabajo o dividirlo en fragmentos. Hay trabajo en progreso en el [nuevo reconciliador Fiber](/docs/codebase-overview.html#fiber-reconciler) con una [arquitectura completamente diferente](https://github.com/acdlite/react-fiber-architecture). En el futuro, pretendemos reemplazar el reconciliador de pila con Fiber, pero por el momento está lejos de igualar sus características.
 
-### Siguientes Pasos {#next-steps}
+### Siguientes pasos {#next-steps}
 
 Lee la [siguiente sección](/docs/design-principles.html) para aprender sobre los principios que nos guían en el desarrollo de React.

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -11,7 +11,7 @@ redirect_from:
 
 Esta sección es una colección de notas de implementación para el [reconciliador de pila](/docs/codebase-overview.html#stack-reconciler).
 
-Es muy técnica y asume un gran entendimiento de la API pública de React como también sobre la división de React en núcleo, renderizadores y el reconciliador. Si no estás muy familiarizado con el código base de React, primero lee la [visión general del código base](/docs/codebase-overview.html).
+Es muy técnica y asume un gran entendimiento de la API pública de React como también sobre la división de React en núcleo, renderizadores y el reconciliador. Si no estás muy familiarizado con la base de código de React, primero lee la [visión general de la base de código](/docs/codebase-overview.html).
 
 Además se asume una buena comprensión de las [diferencias entre componentes de React, sus instancias y sus elementos](/blog/2015/12/18/react-components-elements-and-instances.html).
 
@@ -27,7 +27,7 @@ Tanto este documento como su charla son simplificaciones del código base real p
 
 El reconciliador por sí mismo no tiene una API pública. Los [renderizadores](/docs/codebase-overview.html#stack-renderers) como React DOM y React Native lo usan para actualizar de manera eficiente la interfaz de usuario acorde a los componentes de React diseñados por el usuario. 
 
-### Montando como un Proceso Recursivo {#mounting-as-a-recursive-process}
+### El montaje como un proceso recursivo {#mounting-as-a-recursive-process}
 
 Consideremos la primera vez que montas un componente:
 

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -48,7 +48,7 @@ Si `App` es una función, el reconciliador llamará `App(props)` para renderizar
 
 Si `App` es una clase, el reconciliador instanciará una `App` con `new App(props)`, llamará al método del ciclo de vida `componentWillMount()`, y por último llamará al método `render()` para obtener el elemento renderizado.
 
-De cualquier manera, el reconciliador averiguará a que elemento se renderizó `App`.
+De cualquier manera, el reconciliador averiguará a qué elemento se renderizó `App`.
 
 Este proceso es recursivo. `App` puede ser renderizado como `<Greeting />`, `<Greeting />` puede ser renderizado como `<Button />`, y así sucesivamente. El reconciliador examinará a fondo a través de los componentes definidos por el usuario de manera recursiva a medida que averigua a qué se renderiza cada componente.
 
@@ -64,7 +64,7 @@ function isClass(type) {
 }
 
 // Esta función toma un elemento de React (Por ej. <App />)
-// y devuelve un DOM o un nodo nativo que representa el árbol montado.
+// y devuelve un nodo DOM o nativo que representa el árbol montado.
 function mount(element) {
   var type = element.type;
   var props = element.props;
@@ -85,7 +85,7 @@ function mount(element) {
     // Obtener el elemento renderizado llamando a render()
     renderedElement = publicInstance.render();
   } else {
-    // Componente de función
+    // Función componente
     renderedElement = type(props);
   }
 
@@ -111,22 +111,22 @@ Hagamos un repaso de algunas ideas clave con el ejemplo anterior:
 
 * Los elementos de React son objetos simples que representan el tipo de un componente (Por ej. `App`) y las props.
 * Los componentes definidos por el usuario (Por ej. `App`) pueden ser clases o funciones pero todos "se renderizan" como elementos.
-* El "montaje" es un proceso recursivo que crea un DOM o un árbol nativo dado el elemento de React de mayor nivel (Por ej. `<App />`).
+* El "montaje" es un proceso recursivo que crea un árbol DOM o nativo dado el elemento de React de mayor nivel (Por ej. `<App />`).
 
-### Montando Elementos Principales {#mounting-host-elements}
+### Montaje de elementos anfitriones {#mounting-host-elements}
 
 Este proceso sería inservible si no renderizáramos algo en la pantalla como resultado.
 
-Sumados a los componentes definidos por el usuario o ("compuestos"), los elementos de React también pueden representar componentes específicos a la plataforma o ("principales"). Por ejemplo, `Button` puede devolver un `<div />` desde su método render.
+Sumados a los componentes definidos por el usuario o ("compuestos"), los elementos de React también pueden representar componentes específicos a la plataforma o ("anfitriones"). Por ejemplo, `Button` puede devolver un `<div />` desde su método render.
 
-Si la propiedad `type` de un elemento es una *string*, sabemos que estamos trabajando con un elemento principal:
+Si la propiedad `type` de un elemento es una *string*, sabemos que estamos trabajando con un elemento anfitrión:
 
 ```js
 console.log(<div />);
 // { type: 'div', props: {} }
 ```
 
-No hay código definido por el usuario asociado con elementos principales.
+No hay código definido por el usuario asociado con elementos anfitriones.
 
 Cuando el reconciliador encuentra un elemento principal, deja que el renderizador se encargue de montarlo. Por ejemplo, React DOM podría crear un nodo del DOM.
 
@@ -319,7 +319,7 @@ Esto no es muy diferente de nuestra implementación previa de `mountComposite()`
 
 Ten en cuenta que una instancia de `CompositeComponent` no es lo mismo que una instancia del `element.type` proporcionado por el usuario. `CompositeComponent` es un detalle de la implementación de nuestro reconciliador, y nunca es expuesto al usuario. La clase definida por el usuario es la que leemos en `element.type`, y `CompositeComponent` crea una instancia de esa clase.
 
-Para evitar la confusión, llamaremos a las instancias de `CompositeComponent` y `DOMComponent` "instancias internas". Éstas existen para que podamos asociar datos antiguos a ellas. Sólo el renderizador y el reconciliador estan al tanto de que existen.
+Para evitar la confusión, llamaremos a las instancias de `CompositeComponent` y `DOMComponent` "instancias internas". Estas existen para que podamos asociar datos antiguos a ellas. Solo el renderizador y el reconciliador están al tanto de que existen.
 
 En contraste, llamamos "instancia pública" a una instancia de una clase definida por el usuario. La instancia pública es lo que ves como `this` en `render()` y en otros métodos de tus componentes personalizados.
 
@@ -358,7 +358,7 @@ class DOMComponent {
       }
     });
 
-    // Crear y guardar los hijos incluídos.
+    // Crear y guardar los hijos incluidos.
     // Cada uno de ellos puede ser un DOMComponent o un CompositeComponent,
     // dependiendo de si el tipo del elemento es un string o una función.
     var renderedChildren = children.map(instantiateComponent);
@@ -412,7 +412,7 @@ Si se te dificulta imaginar como está estructurado un árbol de instancias inte
 
  <img src="../images/docs/implementation-notes-tree.png" width="500" style="max-width: 100%" alt="React DevTools tree" />
 
-Para completar este refactoreo, introduciremos una función que monta el árbol completo a un nodo contenedor, al igual que `ReactDOM.render()`. Devuelve una instancia pública, también como `ReactDOM.render()`:
+Para completar esta refactorización, introduciremos una función que monta el árbol completo a un nodo contenedor, al igual que `ReactDOM.render()`. Devuelve una instancia pública, también como `ReactDOM.render()`:
 
 ```js
 function mountTree(element, containerNode) {
@@ -862,9 +862,9 @@ Este documento está simplificado en comparación al código base real. Hay algu
 
 * Los renderizadores usan [inyección](/docs/codebase-overview.html#dynamic-injection) para pasar la clase interna principal al reconciliador. Por ejemplo, React DOM le dice al reconciliador que use `ReactDOMComponent` como la implementación de una instancia interna principal.
 
-* La lógica para actualizar la lista de hijos es extraída a una mezcla llamada `ReactMultiChild` que es utilizada por las implementaciones de clases de instancias internas principales tanto para React DOM como para React Native.
+* La lógica para actualizar la lista de hijos se extrae en un mixin llamado `ReactMultiChild` que es utilizado por las implementaciones de clases de instancias internas principales tanto para React DOM como para React Native.
 
-* El reconciliador además implementa soporte para `setState()` en componentes compuestos. Múltiples actualizaciones dentro de escuchadores de eventos son procesadas por lote en una sola actualización.
+* La implementación del reconciliador también permite el funcionamiento de `setState()` en componentes compuestos. Múltiples actualizaciones dentro de manejadores de eventos son procesadas por lote en una sola actualización.
 
 * El reconciliador también se encarga de adjuntar y desconectar las referencias a componentes compuestos y nodos principales.
 
@@ -879,7 +879,7 @@ Este documento está simplificado en comparación al código base real. Hay algu
 * [`ReactCompositeComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js) es el equivalente a `CompositeComponent` es este tutorial. Maneja las llamadas a componentes definidos por el usuario y el mantenimiento de su estado.
 * [`instantiateReactComponent`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/instantiateReactComponent.js) contiene el interruptor que elige la clase correcta de una instancia interna a construir para un elemento. Es equivalente a `instantiateComponent()` en este tutorial.
 
-* [`ReactReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactReconciler.js) es un *wrapper* que contiene los métodos `mountComponent()`, `receiveComponent()`, y `unmountComponent()`. Llama a las implementaciones subyacentes en las instancias internas, pero también incluye código sobre ellas que es compartido por todas las implementaciones de instancias internas.
+* [`ReactReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactReconciler.js) es un *wrapper* que contiene los métodos `mountComponent()`, `receiveComponent()` y `unmountComponent()`. Llama a las implementaciones subyacentes en las instancias internas, pero también incluye código sobre ellas que es compartido por todas las implementaciones de instancias internas.
 
 * [`ReactChildReconciler`](https://github.com/facebook/react/blob/83381c1673d14cd16cf747e34c945291e5518a86/src/renderers/shared/stack/reconciler/ReactChildReconciler.js) implementa la lógica para montar, actualizar, y desmontar hijos de acuerdo a la `key` de sus elementos.
 
@@ -887,7 +887,7 @@ Este documento está simplificado en comparación al código base real. Hay algu
 
 * `mount()`, `receive()`, y `unmount()` son en realidad llamados `mountComponent()`, `receiveComponent()`, and `unmountComponent()` en el código base de React por razones de herencia, pero reciben elementos.
 
-* Las propiedades en las instancias internas comienzan con un guión bajo, por ej. `_currentElement`. Son considerados campos públicos de sólo lectura a través del código base.
+* Las propiedades en las instancias internas comienzan con un guión bajo, por ej. `_currentElement`. Son considerados campos públicos de solo lectura a través de la base de código.
 
 ### Futuras Orientaciones {#future-directions}
 
@@ -895,4 +895,4 @@ El reconciliador de pila tiene limitaciones inherentes como ser sincrónico y no
 
 ### Siguientes Pasos {#next-steps}
 
-Lee la [siguiente sección](/docs/design-principles.html) para aprender sobre los principios de guía que usamos para el desarrollo de React.
+Lee la [siguiente sección](/docs/design-principles.html) para aprender sobre los principios que nos guían en el desarrollo de React.

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -429,9 +429,9 @@ var rootEl = document.getElementById('root');
 mountTree(<App />, rootEl);
 ```
 
-### Unmounting {#unmounting}
+### Desmontaje {#unmounting}
 
-Now that we have internal instances that hold onto their children and the DOM nodes, we can implement unmounting. For a composite component, unmounting calls a lifecycle method and recurses.
+Ahora que tenemos instancias internas que se aferran a sus hijos y a los nodos del DOM, podemos implementar el desmontaje. Para un elemento compuesto, el desmontaje llama a un método de ciclo de vida y entra en recursión.
 
 ```js
 class CompositeComponent {
@@ -439,7 +439,7 @@ class CompositeComponent {
   // ...
 
   unmount() {
-    // Call the lifecycle method if necessary
+    // Llamar al método del ciclo de vida si es necesario
     var publicInstance = this.publicInstance;
     if (publicInstance) {
       if (publicInstance.componentWillUnmount) {
@@ -447,14 +447,13 @@ class CompositeComponent {
       }
     }
 
-    // Unmount the single rendered component
+    // Desmontar el único componente renderizado
     var renderedComponent = this.renderedComponent;
     renderedComponent.unmount();
   }
 }
 ```
-
-For `DOMComponent`, unmounting tells each child to unmount:
+Para `DomComponent`, el desmontaje le avisa a cada hijo que se debe desmontar:
 
 ```js
 class DOMComponent {
@@ -462,56 +461,56 @@ class DOMComponent {
   // ...
 
   unmount() {
-    // Unmount all the children
+    // Desmontar todos los hijos
     var renderedChildren = this.renderedChildren;
     renderedChildren.forEach(child => child.unmount());
   }
 }
 ```
 
-In practice, unmounting DOM components also removes the event listeners and clears some caches, but we will skip those details.
+En la práctica, desmontar componentes del DOM también remueve los escuchadores de eventos y limpia algunas cachés, pero nos saltearemos esos detalles.
 
-We can now add a new top-level function called `unmountTree(containerNode)` that is similar to `ReactDOM.unmountComponentAtNode()`:
+Ahora podemos agregar una nueva función de mayor nivel llamada `unmountTree(containerNode)` que es similar a `ReactDOM.unmountComponentAtNode()`:
 
 ```js
 function unmountTree(containerNode) {
-  // Read the internal instance from a DOM node:
-  // (This doesn't work yet, we will need to change mountTree() to store it.)
+  // Leer esta instancia interna desde un nodo del DOM:
+  // (Esto no funciona todavía, necesitaremos cambiar mountTree() para guardarlo.)
   var node = containerNode.firstChild;
   var rootComponent = node._internalInstance;
 
-  // Unmount the tree and clear the container
+  // Desmontar el árbol y limpiar el contenedor
   rootComponent.unmount();
   containerNode.innerHTML = '';
 }
 ```
 
-In order for this to work, we need to read an internal root instance from a DOM node. We will modify `mountTree()` to add the `_internalInstance` property to the root DOM node. We will also teach `mountTree()` to destroy any existing tree so it can be called multiple times:
+Para que esto funcione, necesitamos leer una instancia interna raíz de un nodo del DOM. Modificaremos `mountTree()` para agregar la propiedad `_internalInstance` al nodo raíz del DOM. También le enseñaremos a `mountTree()` a destruir cualquier árbol existente así puede ser llamado múltiples veces:
 
 ```js
 function mountTree(element, containerNode) {
-  // Destroy any existing tree
+  // Destruir cualquier árbol existente
   if (containerNode.firstChild) {
     unmountTree(containerNode);
   }
 
-  // Create the top-level internal instance
+  // Creaer la instancia interna de mayor nivel
   var rootComponent = instantiateComponent(element);
 
-  // Mount the top-level component into the container
+  // Montar el componente de mayor nivel al contenedor
   var node = rootComponent.mount();
   containerNode.appendChild(node);
 
-  // Save a reference to the internal instance
+  // Guardar una referencia a la instancia interna
   node._internalInstance = rootComponent;
 
-  // Return the public instance it provides
+  // Devolver la instancia pública que provee
   var publicInstance = rootComponent.getPublicInstance();
   return publicInstance;
 }
 ```
 
-Now, running `unmountTree()`, or running `mountTree()` repeatedly, removes the old tree and runs the `componentWillUnmount()` lifecycle method on components.
+Ahora, ejecutando `unmountTree()`, o ejecutando `mountTree()` repetidamente, remueve el árbol viejo y ejecuta el método de ciclo de vida `componentWillUnmount()` en los componentes.
 
 ### Updating {#updating}
 

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -23,7 +23,7 @@ El reconciliador de pila se usó en React 15 y también en versiones anteriores.
 
 Tanto este documento como su charla son simplificaciones del código base real por lo que obtendrás un mejor entendimiento familiarizándote con ambos.
 
-### Visión General {#overview}
+### Visión general {#overview}
 
 El reconciliador por sí mismo no tiene una API pública. Los [renderizadores](/docs/codebase-overview.html#stack-renderers) como React DOM y React Native lo usan para actualizar de manera eficiente la interfaz de usuario acorde a los componentes de React diseñados por el usuario. 
 


### PR DESCRIPTION
Hi @Darking360, translation is ready for review.

I took some notes to consider:

- Line 47 = **Lifecycle method** = Método de ciclo de vida
- Line 67 = **Native node** = Nodo de React Native o nodo nativo?
- Line 77 = **Component class / function:** I saw other translations using _Componente de clase / función_ but I  think the literal translation would be _clase Component_
- Line 200 = Use **children** or _hijos_ in code snippets
- Line 250 = The literal translation is _fábrica_ but I don't know if it's the best choice.
- Line 531 = Same as factory but with _Contrato_.
- Line 865 = **Extracted into a mixin.** _Puesta en una mezcla_ would accomplish the translation too I think.
- Line 873 = I think **Input** should be used as it is, like _String_.

I expect your feedback.