### PR TITLE
Remover palabra duplicada

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -233,7 +233,7 @@ function FriendStatus(props) {
 
 ## Recapitulación {#recap}
 
-Hemos aprendido que `useEffect` nos permite expresar diferentes tipos de efectos secundarios después de que un componente se renderice. Algunos efectos pueden pueden devolver una función cuando requieran saneamiento:
+Hemos aprendido que `useEffect` nos permite expresar diferentes tipos de efectos secundarios después de que un componente se renderice. Algunos efectos pueden devolver una función cuando requieran saneamiento:
 
 ```js
   useEffect(() => {


### PR DESCRIPTION
Remover la palabra "pueden" que se encontraba duplicada en la sección Recapitulación [ linea 236 ]



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
