### PR TITLE
fix: form superimposed on nav text in some responsive sizes

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -98,8 +98,8 @@ const Header = ({location}: {location: Location}) => (
 
         <nav
           css={{
+            display: 'contents',
             flex: '1',
-            display: 'flex',
             flexDirection: 'row',
             alignItems: 'stretch',
             overflowX: 'auto',


### PR DESCRIPTION
In some responsive sizes, the `form` element was superimposed on the `nav` text.
I hope to continue contributing to this beautiful community :smiley:  :tada: 