### PR TITLE
Fix little typo in components-and-props.md

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -15,7 +15,7 @@ redirect_from:
 prev: rendering-elements.html
 next: state-and-lifecycle.html
 ---
-Los componentes permiten separar la interfaz de usuario en piezas independientes, reutilizables y pensar en cada pieza de forma aislada.Esta página proporciona una introducción a la idea de los componentes.
+Los componentes permiten separar la interfaz de usuario en piezas independientes, reutilizables y pensar en cada pieza de forma aislada. Esta página proporciona una introducción a la idea de los componentes.
 Puedes encontrar una [API detallada sobre componentes aquí](/docs/react-component.html).
 
 Conceptualmente, los componentes son como las funciones de JavaScript. Aceptan entradas arbitrarias (llamadas "props") y devuelven a React elementos que describen lo que debe aparecer en la pantalla.


### PR DESCRIPTION
Add a space between a dot and the consequent word (`. Esta`).
Refer to: https://www.proz.com/kudoz/spanish/linguistics/1450384-%C2%BFcu%C3%A1ntos-espacios-hay-que-poner-despu%C3%A9s-del-punto-y-seguido-en-espa%C3%B1ol.html