### PR TITLE
Change links from english repo to spanish repo

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -124,4 +124,4 @@ Esta documentación siempre refleja la última versión estable de React. Desde 
 
 ## ¿Algo hace falta? {#something-missing}
 
-Si algo hace falta en la documentación, o si estas confundido, por favor [abre un caso en el repositorio de la documentación](https://github.com/reactjs/reactjs.org/issues/new) con tus sugerencias para mejoras, o envía un tweet a la [cuenta de @reactjs](https://twitter.com/reactjs). ¡Nos encanta saber de ti!
+Si algo hace falta en la documentación, o si estas confundido, por favor [abre un caso en el repositorio de la documentación](https://github.com/reactjs/es.reactjs.org/issues/new) con tus sugerencias para mejoras, o envía un tweet a la [cuenta de @reactjs](https://twitter.com/reactjs). ¡Nos encanta saber de ti!

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -131,7 +131,7 @@ const MarkdownPage = ({
                     </span>
                     <a
                       css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/reactjs/reactjs.org/tree/master/${markdownRemark.fields.path}`}>
+                      href={`https://github.com/reactjs/es.reactjs.org/blob/master/${markdownRemark.fields.path}`}>
                       Edita esta página
                     </a>
                   </div>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
* Edited link in `content/docs/getting-started.md` to point to the spanish repo.
* Edited link in `src/components/MarkdownPage/MarkdownPage.js` so "Edit this page" now points to the correct route in spanish repository.

Tested the "Edit this page" link across the routes generated and it works, pointing to the spanish repo.

![image](https://user-images.githubusercontent.com/40344166/94921736-dc1dc780-0486-11eb-84d5-0172dafe75be.png)
