### PR TITLE
Fixed language mistake

### DIFF
--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -265,7 +265,7 @@ function Todos() {
 
 ## Próximos pasos {#next-steps}
 
-¡Uf, eso fue rápido! Si algunas cosas no te hacen mucho sentido o si te gustaría aprender más en detalle, puedes leer las siguientes páginas, comenzando con la documentación de [Hook de estado](/docs/hooks-state.html).
+¡Uf, eso fue rápido! Si algunas cosas no tienen mucho sentido o si te gustaría aprender más en detalle, puedes leer las siguientes páginas, comenzando con la documentación de [Hook de estado](/docs/hooks-state.html).
 
 También puede consultar la [Referencia de la Hooks API](/docs/hooks-reference.html) y las [Preguntas Frecuentes sobre Hooks](/docs/hooks-faq.html).
 


### PR DESCRIPTION
Little common mistake translation from English to Spanish.

"Hacer sentido" is a wrong translation from the english expression "make sense" (Literally: make = hacer ; sense = sentido).

On spanish, the correct translation for that concept it's the expression "tener sentido". "Hacer sentido" does not exists, although it's used erroneously sometimes on the Internet.
