### PR TITLE
Removed duplicated word

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -51,7 +51,7 @@ Esto destruirá el `Counter` viejo y volvera a montar uno nuevo.
 
 ### Elementos del DOM del mismo tipo {#dom-elements-of-the-same-type}
 
-Al comparar dos elementos elementos React DOM del mismo tipo, React analiza los atributos de ambos, mantiene el mismo nodo DOM subyacente, y solo actualiza los atributos modificados. Por ejemplo:
+Al comparar dos elementos React DOM del mismo tipo, React analiza los atributos de ambos, mantiene el mismo nodo DOM subyacente, y solo actualiza los atributos modificados. Por ejemplo:
 
 ```xml
 <div className="before" title="stuff" />


### PR DESCRIPTION
Hola! 

He conseguido que han repetido la palabra elementos en la sección de la documentación de reconciliación y me parece que debe ser un error.

Lo he arreglado :). Espero les sirva de algo y si no es un error pues mis disculpas.

// English

Hi!

I have found that the word 'elementos' was duplicated in the reconciliation section of the docs. I believe this might be a mistake.

I have fixed it :). Hope this is helpfull and if its not an error I offer my apologies.