### PR TITLE
Fix for typo in react memo explanation

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -126,7 +126,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 `React.memo` es un [componente de orden superior](/docs/higher-order-components.html).
 
-Si el componente renderiza el mismo resultado dadas las mismas props, se puede envolver en una llamada a `React.memo` para una mejora en el desempeño en algunos casos memoizando el resultado. Esto significa que React omitirá renderizar el componente y reusará el último resultado renderizado.
+Si el componente renderiza el mismo resultado dadas las mismas props, se puede envolver en una llamada a `React.memo` para una mejora en el desempeño en algunos casos memorizando el resultado. Esto significa que React omitirá renderizar el componente y reusará el último resultado renderizado.
 
 `React.memo` solamente verifica los cambios en las props. Si tu componente de función envuelto en `React.memo` tiene un Hook [`useState`](/docs/hooks-state.html), [`useReducer`](/docs/hooks-reference.html#usereducer) o [`useContext`](/docs/hooks-reference.html#usecontext) en su implementación, continuará volviéndose a renderizar cuando el estado o el contexto cambien.
 


### PR DESCRIPTION
"memoiando". A letter r is lefting, "memorizando"

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
