### PR TITLE
Update tutorial.md

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1054,7 +1054,7 @@ Vamos a discutir que significa la advertencia anterior.
 
 ### Escogiendo una key {#picking-a-key}
 
-Cuando renderizamos una lista, React almacena información acerca de cada elemento de la lista renderizado. Cuando actualizamos una lista, React necesita determinar que ha cambiado. Podríamos haber añadido, eliminado, reacomodado, o actualizado los elementos de la lista.
+Cuando renderizamos una lista, React almacena información acerca de cada elemento de la lista renderizado. Cuando actualizamos una lista, React necesita determinar qué ha cambiado. Podríamos haber añadido, eliminado, reacomodado, o actualizado los elementos de la lista.
 
 Imagina cambiar de
 


### PR DESCRIPTION
When we update a list, React 'needs to determine what has changed' ('necesita determinar qué ha cambiado'),
better than 'needs to determine that has changed' ('necesita determinar que ha cambiado')
El tilde hace la diferencia, como en: 'no tengo qué comer' y 'no tengo que comer'

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
