### PR TITLE
Fixed "library" translations

### DIFF
--- a/content/blog/2019-08-08-react-v16.9.0.md
+++ b/content/blog/2019-08-08-react-v16.9.0.md
@@ -165,7 +165,7 @@ No queremos sobreprometer de nuevo la fecha de liberación. Dado que dependemos 
 
 ### Una actualización sobre la Obtención de Datos {#an-update-on-data-fetching}
 
-Aunque React no es opinionado acerca de como obtienes datos, la primera versión de Suspense para Obtención de Datos probablemente estará enfocada en integrarse con *librerías de obtención de datos opinionadas*. Por ejemplo, en Facebook estamos usando las próximas APIs de Relay que se integran con Suspense. Nosotros documentaremos cómo otras librerías opinionadas como Apollo pueden soportar una integración similar. 
+Aunque React no es opinionado acerca de como obtienes datos, la primera versión de Suspense para Obtención de Datos probablemente estará enfocada en integrarse con *bibliotecas de obtención de datos opinionadas*. Por ejemplo, en Facebook estamos usando las próximas APIs de Relay que se integran con Suspense. Nosotros documentaremos cómo otras bibliotecas opinionadas como Apollo pueden soportar una integración similar. 
 
 En la primera versión, *no* tenemos la intención de enfocarnos en la solución ad-hoc "dispara una solicitud HTTP" que usamos en los demos iniciales (también conocido como "React Cache"). Sin embargo, esperamos que tanto nosotros como la comunidad React estaremos explorando este espacio en los próximos meses luego de la versión inicial.
 

--- a/content/blog/2021-06-08-the-plan-for-react-18.md
+++ b/content/blog/2021-06-08-the-plan-for-react-18.md
@@ -11,9 +11,9 @@ El equipo de React está emocionado por compartir algunas novedades:
 
 1. Empezamos a trabajar en el lanzamiento de React 18, el cual será nuestra próxima versión mayor.
 2. Creamos un Working Group para preparar a la comunidad ante una adopción gradual de las nuevas características en React 18.
-3. Publicamos React 18 Alpha para que los autores de librerías puedan probarlo y dar feedback.
+3. Publicamos React 18 Alpha para que los autores de bibliotecas puedan probarlo y dar feedback.
 
-Estas actualizaciones son principalmente apuntado a los mantenedores de otras librerías. Si estás aprendiendo, enseñando o usando React para construir aplicaciones para usuarios, puedes ignorar esta publicación de manera segura. ¡Pero eres bienvenido de seguir las discusiones en el React 18 Working Group si eres curioso!
+Estas actualizaciones son principalmente apuntado a los mantenedores de otras bibliotecas. Si estás aprendiendo, enseñando o usando React para construir aplicaciones para usuarios, puedes ignorar esta publicación de manera segura. ¡Pero eres bienvenido de seguir las discusiones en el React 18 Working Group si eres curioso!
 
 ## Qué viene en React 18 {#whats-coming-in-react-18}
 
@@ -31,9 +31,9 @@ Enviamos con éxito características concurrentes a decenas de miles de componen
 
 ## Trabajando con la comunidad {#working-with-the-community}
 
-Estamos probando algo nuevo para esta versión: hemos invitado a un panel de expertos, desarrolladores, autores de librerías y educadores de toda la comunidad de React para participar en nuestro [React 18 Working Group](https://github.com/reactwg/react-18) para proporcionar comentarios, hacer preguntas y colaborar en el lanzamiento. No pudimos invitar a todos los que queríamos a este pequeño grupo inicial, pero si este experimento funciona, ¡esperamos que haya más en el futuro!
+Estamos probando algo nuevo para esta versión: hemos invitado a un panel de expertos, desarrolladores, autores de bibliotecas y educadores de toda la comunidad de React para participar en nuestro [React 18 Working Group](https://github.com/reactwg/react-18) para proporcionar comentarios, hacer preguntas y colaborar en el lanzamiento. No pudimos invitar a todos los que queríamos a este pequeño grupo inicial, pero si este experimento funciona, ¡esperamos que haya más en el futuro!
 
-**El objetivo del React 18 Working Group es preparar el ecosistema para una adopción gradual y sin problemas de React 18 por parte de las aplicaciones y librerías existentes.** El Working Group está alojado en [GitHub Discussions](https://github.com/reactwg/react-18/discussions) y está disponible para su lectura pública. Los miembros del grupo de trabajo pueden dejar comentarios, hacer preguntas y compartir ideas. El equipo central también utilizará el repositorio de discusiones para compartir los hallazgos de nuestra investigación. A medida que se acerque la versión estable, también se publicará en este blog cualquier información importante.
+**El objetivo del React 18 Working Group es preparar el ecosistema para una adopción gradual y sin problemas de React 18 por parte de las aplicaciones y bibliotecas existentes.** El Working Group está alojado en [GitHub Discussions](https://github.com/reactwg/react-18/discussions) y está disponible para su lectura pública. Los miembros del grupo de trabajo pueden dejar comentarios, hacer preguntas y compartir ideas. El equipo central también utilizará el repositorio de discusiones para compartir los hallazgos de nuestra investigación. A medida que se acerque la versión estable, también se publicará en este blog cualquier información importante.
 
 Para obtener más información sobre la actualización a React 18, o recursos adicionales sobre el lanzamiento, consulte la [publicación del anuncio de React 18](https://github.com/reactwg/react-18/discussions/4).
 
@@ -55,7 +55,7 @@ Puede haber cambios significativos de comportamiento o de API entre las versione
 
 No tenemos programada una fecha de lanzamiento específica, pero esperamos que sean necesarios varios meses de comentarios e iteraciones antes de que React 18 esté listo para la mayoría de las aplicaciones de producción.
 
-* Librería Alpha: Disponible hoy
+* Biblioteca Alpha: Disponible hoy
 * Beta público: Al menos en varios meses
 * Candidato de lanzamiento (RC): Al menos varias semanas después del Beta
 * General Availability: Al menos varias semanas después de RC

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -58,7 +58,7 @@ Antes de continuar, debes notar que los Hooks son:
 
 ## Motivación {#motivation}
 
-Los Hooks resuelven una amplia variedad de problemas aparentemente desconectados en React que hemos encontrado durante más de cinco años de escribir y mantener decenas de miles de componentes. Ya sea que estés aprendiendo React, usándolo diariamente o incluso prefieras una librería diferente con un modelo de componentes similar, es posible que reconozcas algunos de estos problemas.
+Los Hooks resuelven una amplia variedad de problemas aparentemente desconectados en React que hemos encontrado durante más de cinco años de escribir y mantener decenas de miles de componentes. Ya sea que estés aprendiendo React, usándolo diariamente o incluso prefieras una biblioteca diferente con un modelo de componentes similar, es posible que reconozcas algunos de estos problemas.
 
 ### Es difícil reutilizar la lógica de estado entre componentes {#its-hard-to-reuse-stateful-logic-between-components}
 
@@ -72,7 +72,7 @@ Discutiremos esto más a fondo en [Construyendo tus propios Hooks](/docs/hooks-c
 
 A menudo tenemos que mantener componentes que empiezan simples pero con el pasar del tiempo crecen y se convierten en un lío inmanejable de multiples lógicas de estado y efectos secundarios. Cada método del ciclo de vida a menudo contiene una mezcla de lógica no relacionada entre sí. Por ejemplo, los componentes pueden realizar alguna consulta de datos en el `componentDidMount` y `componentDidUpdate`. Sin embargo, el mismo método `componentDidMount` también puede contener lógica no relacionada que cree escuchadores de eventos, y los limpie en el `componentWillUnmount`. El código relacionado entre sí y que cambia a la vez es separado, pero el código que no tiene nada que ver termina combinado en un solo método. Esto hace que sea demasiado fácil introducir errores e inconsistencias.
 
-En muchos casos no es posible dividir estos componentes en otros más pequeños porque la lógica de estado está por todas partes. También es difícil probarlos. Esta es una de las razones por las que muchas personas prefieren combinar React con una librería de administración de estado separada. Sin embargo, esto a menudo introduce demasiada abstracción, requiere que saltes entre diferentes archivos, y hace que la reutilización de componentes sea más difícil.
+En muchos casos no es posible dividir estos componentes en otros más pequeños porque la lógica de estado está por todas partes. También es difícil probarlos. Esta es una de las razones por las que muchas personas prefieren combinar React con una biblioteca de administración de estado separada. Sin embargo, esto a menudo introduce demasiada abstracción, requiere que saltes entre diferentes archivos, y hace que la reutilización de componentes sea más difícil.
 
 Para resolver esto, **Hooks te permite dividir un componente en funciones más pequeñas basadas en las piezas relacionadas (como la configuración de una suscripción o la consulta de datos)**,  en lugar de forzar una división basada en los métodos del ciclo de vida. También puedes optar por administrar el estado local del componente con un _reducer_ para hacerlo más predecible.
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -126,7 +126,7 @@ Ahora que está tu entorno configurado, ¡vamos a obtener una visión general de
 
 ### ¿Qué es React? {#what-is-react}
 
-React es una librería de JavaScript declarativa, eficiente y flexible para construir interfaces de usuario. Permite componer IUs complejas de pequeñas y aisladas piezas de código llamadas "componentes".
+React es una biblioteca de JavaScript declarativa, eficiente y flexible para construir interfaces de usuario. Permite componer IUs complejas de pequeñas y aisladas piezas de código llamadas "componentes".
 
 React tiene pocos tipos diferentes de componentes, pero vamos a empezar con la subclase `React.Component`:
 


### PR DESCRIPTION
Fixed all "library" mistranslations. Replaced "librería" for "biblioteca" and "librerías" for "bibliotecas"

@carburo @Darking360