### PR TITLE
Actualizar palabra experamos por esperamos

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -91,7 +91,7 @@ Los Hooks tienen también su propia curva de aprendizaje. Si hay algo faltante e
 
 Cuando estés listo, te recomendamos empezar a usar Hooks en los nuevos componentes que escribas. Asegúrate que todo tu equipo esté de acuerdo en usarlos, y que estén familiarizados con esta documentación. No recomendamos reescribir tus clases existentes a menos de que hayas planeado reescribirlas de cualquier manera (por ejemplo para arreglar bugs).
 
-No puedes usar Hooks *dentro* de un componente de clase, pero definitivamente puedes mezclar componentes de clase y componentes de función con Hooks en un mismo árbol. Si un componente es una clase, o una función que utiliza Hooks es un detalle de implementación del Componente. A largo plazo, experamos que los Hooks sean la manera más usada de escribir Componentes de React.
+No puedes usar Hooks *dentro* de un componente de clase, pero definitivamente puedes mezclar componentes de clase y componentes de función con Hooks en un mismo árbol. Si un componente es una clase, o una función que utiliza Hooks es un detalle de implementación del Componente. A largo plazo, esperamos que los Hooks sean la manera más usada de escribir Componentes de React.
 
 ### ¿Cubren los Hooks todos los casos de uso de las clases? {#do-hooks-cover-all-use-cases-for-classes}
 


### PR DESCRIPTION
En le sección ¿Debería usar Hooks, clases, o una mezcla de ambos? se tiene la frase:
A largo plazo, experamos que los Hooks sean la manera más usada de escribir Componentes de React.
La palabra experamos no es correcta, mientras que esperamos es el termino ideal.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
