### PR TITLE
fix: corregir relación de aspecto de logo alternativo en página de inicio

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -517,10 +517,10 @@ export function HomeContent() {
               <Image
                 alt="logo by @sawaratsuki1004"
                 title="logo by @sawaratsuki1004"
-                className="uwu-visible mb-10 lg:mb-8 h-24 lg:h-32"
+                className="uwu-visible mb-10 lg:mb-8 h-24 lg:h-32 w-auto"
                 src="/images/uwu.png"
-                width={100}
-                height={100}
+                width={313}
+                height={160}
               />
             </div>
             <Logo className="uwu-hidden text-brand dark:text-brand-dark w-24 lg:w-28 mb-10 lg:mb-8 mt-12 h-auto mx-auto self-start" />


### PR DESCRIPTION
### Descripción del Cambio
Se corrigió un problema visual en el componente `HomeContent` donde el logo alternativo de la comunidad se mostraba deformado y estirado verticalmente. 

Para solucionarlo, se aplicó la clase `w-auto` de Tailwind CSS y se actualizaron las dimensiones nativas de la imagen (`width={313}` y `height={160}`) para que coincidan con la relación de aspecto original del diseño de @sawaratsuki1004.

### Capturas de pantalla (Antes y Después)

| Antes del cambio (Deformado) | Después del cambio (Corregido) |
| --- | --- |
| <img width="1263" height="746" alt="image" src="https://github.com/user-attachments/assets/6c846c57-533c-43c1-a9fc-95e8da27167f" /> | <img width="1263" height="746" alt="image" src="https://github.com/user-attachments/assets/0eba15c6-1880-48a7-bf58-98a9a9ff313b" /> |
