### PR TITLE
Traduce el índice de React Compiler

### DIFF
--- a/src/content/learn/react-compiler/index.md
+++ b/src/content/learn/react-compiler/index.md
@@ -1,0 +1,31 @@
+---
+title: React Compiler
+---
+
+## Introducción {/*introduction*/}
+
+Aprende [qué hace React Compiler](/learn/react-compiler/introduction) y cómo optimiza automáticamente tu aplicación de React al encargarse de la memoización por ti, eliminando la necesidad de usar manualmente `useMemo`, `useCallback` y `React.memo`.
+
+## Instalación {/*installation*/}
+
+Empieza con [la instalación de React Compiler](/learn/react-compiler/installation) y aprende cómo configurarlo con tus herramientas de compilación.
+
+## Adopción incremental {/*incremental-adoption*/}
+
+Aprende [estrategias para adoptar React Compiler gradualmente](/learn/react-compiler/incremental-adoption) en tu base de código existente si todavía no estás listo para habilitarlo en todas partes.
+
+## Depuración y solución de problemas {/*debugging-and-troubleshooting*/}
+
+Cuando las cosas no funcionan como se espera, usa nuestra [guía de depuración](/learn/react-compiler/debugging) para entender la diferencia entre errores del compilador y problemas de ejecución, identificar patrones comunes que rompen el código y seguir un flujo de depuración sistemático.
+
+## Configuración y referencia {/*configuration-and-reference*/}
+
+Para opciones de configuración detalladas y la referencia de la API:
+
+- [Opciones de configuración](/reference/react-compiler/configuration) - Todas las opciones de configuración del compilador, incluida la compatibilidad con versiones de React
+- [Directivas](/reference/react-compiler/directives) - Control de compilación a nivel de funciones
+- [Compilar librerías](/reference/react-compiler/compiling-libraries) - Publicar librerías precompiladas
+
+## Recursos adicionales {/*additional-resources*/}
+
+Además de esta documentación, recomendamos consultar el [grupo de trabajo de React Compiler](https://github.com/reactwg/react-compiler) para obtener más información y participar en discusiones sobre el compilador.


### PR DESCRIPTION
Traduce la página de índice de `learn/react-compiler` al español, manteniendo los enlaces y encabezados del contenido original.
